### PR TITLE
fix:  localstorage값을 가져오지 못하는 버그 수정

### DIFF
--- a/FE/src/apis/instance.ts
+++ b/FE/src/apis/instance.ts
@@ -19,6 +19,7 @@ const https = axios.create({
 
 https.interceptors.request.use(
   async (config) => {
+    if (typeof window === "undefined") return config;
     const accessToken = localStorage.getItem("accessToken")?.replace(/"/g, "");
     const tokenExpiration = localStorage.getItem("tokenExpiration");
 


### PR DESCRIPTION
## 📌 관련 이슈
close #10 

## ✨ PR 내용

서버단에서 실행시, window 객체가 준비되기 전에 요청하여 window 객체가 없는 버그.
토큰을 가져오기 전 window 객체가 준비되었는지 확인하는 로직 추가
- 토큰을 가져오는 로직은 axios의 interceptors 에 존재
- window가 준비되었는지 확인하는 로직을 추가. window가 존재하면 토큰을 가져오도록 수정

## 주의 사항
