### PR TITLE
feat: api 테스트를 위한 버튼 추가

### DIFF
--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -87,6 +87,7 @@ export interface PostProgramRequest
 }
 
 export const sendMessage = async (programId: number) => {
+  if (!window) return;
   const isConfirmed = confirm("메시지를 보내시겠습니까?");
   if (!isConfirmed) return;
 

--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -86,6 +86,19 @@ export interface PostProgramRequest
   members: { memberId: number }[];
 }
 
+export const sendMessage = async (programId: number) => {
+  const isConfirmed = confirm("메시지를 보내시겠습니까?");
+  if (!isConfirmed) return;
+
+  return await https({
+    url: API.PROGRAM.SEND_MESSAGE(programId),
+    method: "POST",
+    data: {
+      programUrl: "https://econo.eeos.store/detail/" + programId,
+    },
+  });
+};
+
 export const postProgram = async (
   body: PostProgramRequest,
 ): Promise<ProgramIdDto> => {

--- a/FE/src/components/programDetail/program/ProgramInfo.tsx
+++ b/FE/src/components/programDetail/program/ProgramInfo.tsx
@@ -3,6 +3,7 @@
 import ProgramDetail from "./ProgramDetail";
 import ProgramHeader from "./ProgramHeader";
 import ProgramInfoLoader from "./ProgramInfo.loader";
+import { sendMessage } from "@/apis/program";
 import { useGetProgramById } from "@/hooks/query/useProgramQuery";
 
 interface ProgramInfoProps {
@@ -21,6 +22,7 @@ const ProgramInfo = ({ programId }: ProgramInfoProps) => {
 
   return (
     <section className="space-y-8">
+      <button onClick={() => sendMessage(+programId)}>메시지 보내기</button>
       <ProgramHeader data={programData} />
       <ProgramDetail data={programData} />
     </section>

--- a/FE/src/constants/API.ts
+++ b/FE/src/constants/API.ts
@@ -7,6 +7,8 @@ const PROGRAM = {
   DETAIL: (programId: number) => `/programs/${programId}`,
   GUEST_DETAIL: (programId: number) => `/guest/programs/${programId}`,
   ACCESS_RIGHT: (programId: number) => `/programs/${programId}/accessRight`,
+  SEND_MESSAGE: (programId: number) =>
+    `/programs/${programId}/slack/notification`,
 };
 
 const MEMBER = {


### PR DESCRIPTION
## 📌 관련 이슈
#15 

## ✨ PR 내용
api 테스트를 위한 버튼을 추가하였습니다. 
버튼의 위치는 행사 상세정보 페이지에 있으며, 클릭시 api 를 실행합니다. 


## 주의 사항
아직 이슈가 완료되지 않았습니다. 추가적인 pr 이 올라올 예정입니다. 
