### PR TITLE
feat: 계시글 업로드시 슬랙 공지 알림 보내기

### DIFF
--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -86,10 +86,16 @@ export interface PostProgramRequest
   members: { memberId: number }[];
 }
 
-export const sendSlackMessage = async (programId: number) => {
+export const sendSlackMessage = async (
+  programId: number,
+  isRetry: boolean = false,
+) => {
   if (!window) return;
-  const isConfirmed = confirm("메시지를 보내시겠습니까?");
-  if (!isConfirmed) return;
+
+  if (!isRetry) {
+    const isConfirmed = confirm(MESSAGE.SLACK_MESSAGE.CONFIRM);
+    if (!isConfirmed) return;
+  }
 
   return await https({
     url: API.PROGRAM.SEND_MESSAGE(programId),
@@ -99,8 +105,11 @@ export const sendSlackMessage = async (programId: number) => {
         process.env.NEXT_PUBLIC_SLACK_MESSAGE_REQUEST_URL_PREFIX + programId,
     },
   })
-    .then(() => alert("메시지를 성공적으로 전송했습니다."))
-    .catch(() => alert("메시지 전송에 실패했습니다."));
+    .then(() => alert(MESSAGE.SLACK_MESSAGE.SUCCESS))
+    .catch(() => {
+      const retry = confirm(MESSAGE.SLACK_MESSAGE.FAIL);
+      if (retry) sendSlackMessage(programId);
+    });
 };
 
 export const postProgram = async (

--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -86,7 +86,7 @@ export interface PostProgramRequest
   members: { memberId: number }[];
 }
 
-export const sendMessage = async (programId: number) => {
+export const sendSlackMessage = async (programId: number) => {
   if (!window) return;
   const isConfirmed = confirm("메시지를 보내시겠습니까?");
   if (!isConfirmed) return;

--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -95,9 +95,12 @@ export const sendSlackMessage = async (programId: number) => {
     url: API.PROGRAM.SEND_MESSAGE(programId),
     method: "POST",
     data: {
-      programUrl: "https://econo.eeos.store/detail/" + programId,
+      programUrl:
+        process.env.NEXT_PUBLIC_SLACK_MESSAGE_REQUEST_URL_PREFIX + programId,
     },
-  });
+  })
+    .then(() => alert("메시지를 성공적으로 전송했습니다."))
+    .catch(() => alert("메시지 전송에 실패했습니다."));
 };
 
 export const postProgram = async (

--- a/FE/src/components/programDetail/program/ProgramInfo.tsx
+++ b/FE/src/components/programDetail/program/ProgramInfo.tsx
@@ -3,8 +3,6 @@
 import ProgramDetail from "./ProgramDetail";
 import ProgramHeader from "./ProgramHeader";
 import ProgramInfoLoader from "./ProgramInfo.loader";
-// TODO: 기능 구현 이후 삭제하기
-import { sendSlackMessage } from "@/apis/program";
 import { useGetProgramById } from "@/hooks/query/useProgramQuery";
 
 interface ProgramInfoProps {
@@ -23,10 +21,6 @@ const ProgramInfo = ({ programId }: ProgramInfoProps) => {
 
   return (
     <section className="space-y-8">
-      {/* TODO: 기능 구현 이후 삭제하기 */}
-      <button onClick={() => sendSlackMessage(+programId)}>
-        메시지 보내기
-      </button>
       <ProgramHeader data={programData} />
       <ProgramDetail data={programData} />
     </section>

--- a/FE/src/components/programDetail/program/ProgramInfo.tsx
+++ b/FE/src/components/programDetail/program/ProgramInfo.tsx
@@ -3,7 +3,8 @@
 import ProgramDetail from "./ProgramDetail";
 import ProgramHeader from "./ProgramHeader";
 import ProgramInfoLoader from "./ProgramInfo.loader";
-import { sendMessage } from "@/apis/program";
+// TODO: 기능 구현 이후 삭제하기
+import { sendSlackMessage } from "@/apis/program";
 import { useGetProgramById } from "@/hooks/query/useProgramQuery";
 
 interface ProgramInfoProps {
@@ -22,7 +23,10 @@ const ProgramInfo = ({ programId }: ProgramInfoProps) => {
 
   return (
     <section className="space-y-8">
-      <button onClick={() => sendMessage(+programId)}>메시지 보내기</button>
+      {/* TODO: 기능 구현 이후 삭제하기 */}
+      <button onClick={() => sendSlackMessage(+programId)}>
+        메시지 보내기
+      </button>
       <ProgramHeader data={programData} />
       <ProgramDetail data={programData} />
     </section>

--- a/FE/src/constants/MESSAGE.ts
+++ b/FE/src/constants/MESSAGE.ts
@@ -41,6 +41,13 @@ const TEAM_BUILDING = {
   INCREATABLE: "진행중인 팀빌딩이 있어 팀빌딩을 생성할 수 없습니다.",
 };
 
+const SLACK_MESSAGE = {
+  CONFIRM:
+    "슬랙 알림을 보내시겠습니까? 슬랙 알림은 공지사항 채널에 전송됩니다.",
+  SUCCESS: "슬랙 알림이 성공적으로 보내졌습니다! 공지사항 채널을 확인해주세요",
+  FAIL: "알 수 없는 이유로 슬랙 알림 전송에 실패했습니다. 다시 시도하겠습니까?",
+};
+
 Object.freeze(EDIT_DISABLED);
 Object.freeze(AUTH);
 Object.freeze(EDIT);
@@ -59,4 +66,5 @@ export default {
   CONFIRM,
   TEAM_BUILDING,
   COMPLATE,
+  SLACK_MESSAGE,
 };

--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -10,6 +10,7 @@ import {
   getProgramList,
   patchProgram,
   postProgram,
+  sendSlackMessage,
 } from "@/apis/program";
 import API from "@/constants/API";
 import ROUTES from "@/constants/ROUTES";
@@ -26,10 +27,14 @@ export const useCreateProgram = ({ programData, formReset }: CreateProgram) => {
 
   return useMutation({
     mutationKey: [API.PROGRAM.CREATE],
-    mutationFn: () => postProgram(programData),
-    onSettled: (data) => {
+    mutationFn: async () => {
+      const { programId } = await postProgram(programData);
+      await sendSlackMessage(programId);
+      return programId;
+    },
+    onSuccess: (programId) => {
       formReset();
-      data && router.replace(ROUTES.DETAIL(data?.programId));
+      programId && router.replace(ROUTES.DETAIL(programId));
     },
   });
 };

--- a/FE/src/utils/authWithStorage.ts
+++ b/FE/src/utils/authWithStorage.ts
@@ -31,7 +31,7 @@ export const getTokenExpiration = () => {
 };
 
 export const CheckIsLoggedIn = () => {
-  if (!window) return false;
+  if (typeof window !== "undefined") return false;
   const accessToken = getAccessToken();
   const tokenExpiration = getTokenExpiration();
 

--- a/FE/src/utils/authWithStorage.ts
+++ b/FE/src/utils/authWithStorage.ts
@@ -31,7 +31,7 @@ export const getTokenExpiration = () => {
 };
 
 export const CheckIsLoggedIn = () => {
-  if (typeof window !== "undefined") return false;
+  // if (typeof window !== "undefined") return false;
   const accessToken = getAccessToken();
   const tokenExpiration = getTokenExpiration();
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #15 

## ✨ PR 내용
행사를 생성하면 슬랙에 공지 알림이 가도록 기능 추가
- 슬랙 알림 요청을 위한 api를 추가하였습니다.
- api의 순서가 중요한 요청이므로(계시글 요청 -> 슬랙 알림 요청) 하나의 queryFn에 두 가지 서버 요청을 합니다.


## 주의 사항

