### PR TITLE
feat: detail페이지의 사용자 참석 리스트를 드래그하지 못하도록 수정 (MemberList.tsx)

### DIFF
--- a/FE/src/components/common/MemberList.tsx
+++ b/FE/src/components/common/MemberList.tsx
@@ -21,7 +21,7 @@ const MemberList = ({ members, blur = false }: MemberListProps) => {
 
 const MemberListItem = ({ name }: Omit<SimpleMemberInfo, "memberId">) => {
   return (
-    <div className="grid w-fit grid-cols-1 justify-items-center px-4 py-6 text-lg">
+    <div className="grid w-fit cursor-default select-none grid-cols-1 justify-items-center px-4 py-6 text-lg">
       <span>{name}</span>
     </div>
   );


### PR DESCRIPTION
## 📌 관련 이슈
#9 

## ✨ PR 내용
게스트모드에서 사용자의 참석 여부를 확인하지 못하도록 하는 정책에 맞추기 위하여, 사용자의 참석 리스트를 확인하지 못하도록 드래그를 방지하기 위해 user-select를 none으로 설정.
