### PR TITLE
[FEAT] 프로그램 출석 상태 변경 구현

### DIFF
--- a/FE/src/apis/dtos/program.dto.ts
+++ b/FE/src/apis/dtos/program.dto.ts
@@ -5,6 +5,7 @@ import {
   ProgramStatus,
   ProgramCategory,
   AccessRight,
+  ProgramAttendStatus,
 } from "@/types/program";
 
 export class ProgramIdDto {
@@ -24,7 +25,7 @@ export class ProgramInfoDto {
   public readonly programStatus: ProgramStatus;
   public readonly type: ProgramType;
   public readonly accessRight: AccessRight;
-  public readonly attend_mode: "attend" | "late" | "non_open";
+  public readonly attend_mode: ProgramAttendStatus;
   public readonly programGithubUrl: string;
 
   constructor(data: ProgramInfo) {
@@ -48,7 +49,7 @@ export class ProgramSimpleInfoDto {
   public readonly category: ProgramCategory;
   public readonly programStatus: ProgramStatus;
   public readonly type: ProgramType;
-  public readonly attend_mode: "attend" | "late" | "non_open";
+  public readonly attend_mode: ProgramAttendStatus;
 
   constructor(data: ProgramSimpleInfo) {
     this.programId = data?.programId;

--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -2,6 +2,7 @@ import { toast } from "react-toastify";
 import API from "../constants/API";
 import { AttendStatus } from "../types/member";
 import {
+  ProgramAttendStatus,
   ProgramCategoryWithAll,
   ProgramInfo,
   ProgramStatus,
@@ -208,5 +209,20 @@ export const getProgramAccessRight = async (
     url: API.PROGRAM.ACCESS_RIGHT(programId),
     method: "GET",
   });
+  return data?.data;
+};
+
+export const updateProgramAttendMode = async (
+  programId: number,
+  attendMode: ProgramAttendStatus,
+) => {
+  const { data } = await https({
+    url: API.PROGRAM.UPDATE_ATTEND_MODE(programId),
+    method: "POST",
+    params: {
+      mode: attendMode,
+    },
+  });
+
   return data?.data;
 };

--- a/FE/src/app/(admin)/admin/detail/[programId]/page.tsx
+++ b/FE/src/app/(admin)/admin/detail/[programId]/page.tsx
@@ -13,7 +13,7 @@ const ProgramDetailPage = ({ params }: ProgramDetailPageProps) => {
 
   return (
     <div className="mb-16 space-y-16">
-      <ProgramInfo programId={+programId} AccessType="admin" />
+      <ProgramInfo programId={+programId} accessType="admin" />
       <AttendeeInfoContainer programId={+programId} isLoggedIn />
       <UserAttendModalContainer programId={+programId} isLoggedIn />
     </div>

--- a/FE/src/app/(guest)/guest/detail/[programId]/page.tsx
+++ b/FE/src/app/(guest)/guest/detail/[programId]/page.tsx
@@ -13,7 +13,7 @@ const ProgramDetailPage = ({ params }: ProgramDetailPageProps) => {
 
   return (
     <div className="mb-16 space-y-16">
-      <ProgramInfo programId={+programId} AccessType="public" />
+      <ProgramInfo programId={+programId} accessType="public" />
       <AttendeeInfoContainer programId={+programId} isLoggedIn={false} />
       <UserAttendModalContainer programId={+programId} isLoggedIn={false} />
     </div>

--- a/FE/src/app/(private)/(program)/detail/[programId]/page.tsx
+++ b/FE/src/app/(private)/(program)/detail/[programId]/page.tsx
@@ -13,7 +13,7 @@ const ProgramDetailPage = ({ params }: ProgramDetailPageProps) => {
 
   return (
     <div className="mb-16 space-y-16">
-      <ProgramInfo programId={+programId} AccessType="private" />
+      <ProgramInfo programId={+programId} accessType="private" />
       <AttendeeInfoContainer programId={+programId} isLoggedIn />
       <UserAttendModalContainer programId={+programId} isLoggedIn />
     </div>

--- a/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
+++ b/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
@@ -1,0 +1,120 @@
+// TODO: 리팩토링 필요
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { ProgramInfoDto } from "@/apis/dtos/program.dto";
+import StatusToggleItem from "@/components/common/StatusToggleItem";
+import Title from "@/components/common/Title";
+import API from "@/constants/API";
+import { useUpdateProgramAttendMode } from "@/hooks/query/useProgramQuery";
+import { ProgramAttendStatus } from "@/types/program";
+
+interface ProgramAttendStatusManageSectionProps {
+  programId: number;
+}
+const ProgramAttendStatusManageSection = ({
+  programId,
+}: ProgramAttendStatusManageSectionProps) => {
+  const queryClient = useQueryClient();
+  const {
+    mutate: updateProgramAttendMode,
+    isSuccess,
+    isLoading,
+  } = useUpdateProgramAttendMode(programId);
+  const [attendStatus, setAttendStatus] =
+    useState<ProgramAttendStatus>("non_open");
+
+  useEffect(() => {
+    const currentProgramAttendStatus = queryClient.getQueryData<ProgramInfoDto>(
+      [API.PROGRAM.Edit_DETAIL(programId)],
+    )?.attend_mode;
+    setAttendStatus(currentProgramAttendStatus);
+  }, [queryClient, programId, setAttendStatus, isLoading]);
+
+  const setAttendStatusToAttend = () => {
+    if (attendStatus === "non_open") return;
+    updateProgramAttendMode("attend");
+    isSuccess && setAttendStatus("attend");
+  };
+
+  const setAttendStatusToLate = () => {
+    if (attendStatus === "non_open") return;
+    updateProgramAttendMode("late");
+    isSuccess && setAttendStatus("late");
+  };
+
+  const closeAttend = () => {
+    updateProgramAttendMode("non_open");
+    isSuccess && setAttendStatus("non_open");
+  };
+
+  const startAttend = () => {
+    updateProgramAttendMode("attend");
+    isSuccess && setAttendStatus("attend");
+  };
+
+  return (
+    <>
+      <section>
+        <Title text="출석 체크 관리하기" />
+        <div className="mt-4" />
+        <div className="flex items-center justify-between rounded-2xl bg-slate-50 p-8">
+          <p className="text-xl font-semibold">출석 체크 상태</p>
+          <div className="flex gap-8">
+            <div className="flex rounded-full border bg-gray-10">
+              {attendStatus === "attend" ? (
+                <>
+                  <button
+                    onClick={setAttendStatusToAttend}
+                    disabled={isLoading}
+                  >
+                    <StatusToggleItem color="green" text="참석" />
+                  </button>
+                  <button onClick={setAttendStatusToLate} disabled={isLoading}>
+                    <StatusToggleItem color="gray" text="지각" />
+                  </button>
+                </>
+              ) : attendStatus === "late" ? (
+                <>
+                  <button
+                    onClick={setAttendStatusToAttend}
+                    disabled={isLoading}
+                  >
+                    <StatusToggleItem color="gray" text="참석" />
+                  </button>
+                  <button onClick={setAttendStatusToLate} disabled={isLoading}>
+                    <StatusToggleItem color="yellow" text="지각" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    onClick={setAttendStatusToAttend}
+                    disabled={isLoading}
+                  >
+                    <StatusToggleItem color="gray" text="참석" />
+                  </button>
+                  <button onClick={setAttendStatusToLate} disabled={isLoading}>
+                    <StatusToggleItem color="gray" text="지각" />
+                  </button>
+                </>
+              )}
+            </div>
+            {attendStatus === "non_open" ? (
+              <button onClick={startAttend} disabled={isLoading}>
+                <StatusToggleItem color="teal" text="출석체크 시작하기" />
+              </button>
+            ) : (
+              <button onClick={closeAttend} disabled={isLoading}>
+                <StatusToggleItem color="red" text="출석체크 종료하기" />
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+      <div className="mt-20" />
+    </>
+  );
+};
+
+export default ProgramAttendStatusManageSection;

--- a/FE/src/components/programDetail/program/ProgramDetail.tsx
+++ b/FE/src/components/programDetail/program/ProgramDetail.tsx
@@ -1,3 +1,4 @@
+import ProgramAttendStatusManageSection from "./ProgramAttendStatusManageSection";
 import ProgramDashboard from "./ProgramDashboard";
 import ProgramPresentations from "./ProgramPresentations";
 import { ProgramInfoDto } from "@/apis/dtos/program.dto";
@@ -14,16 +15,14 @@ const ProgramDetail = ({ data, programId, accessType }: ProgramDetailProps) => {
   const isGuest = accessType === "public";
   const isAdmin = accessType === "admin";
 
-  console.log(accessType);
-
   const { content } = data;
   return (
     <div>
       <MarkdownViewer value={content} />
+      {isAdmin && <ProgramAttendStatusManageSection programId={programId} />}
       <ProgramPresentations programId={programId} />
       <div className="mt-12">
         <ProgramDashboard programId={programId} isGuest={isGuest} />
-        {isAdmin && <div className="mt-8">hihihihi</div>}
       </div>
     </div>
   );

--- a/FE/src/components/programDetail/program/ProgramDetail.tsx
+++ b/FE/src/components/programDetail/program/ProgramDetail.tsx
@@ -12,6 +12,10 @@ interface ProgramDetailProps {
 
 const ProgramDetail = ({ data, programId, accessType }: ProgramDetailProps) => {
   const isGuest = accessType === "public";
+  const isAdmin = accessType === "admin";
+
+  console.log(accessType);
+
   const { content } = data;
   return (
     <div>
@@ -19,6 +23,7 @@ const ProgramDetail = ({ data, programId, accessType }: ProgramDetailProps) => {
       <ProgramPresentations programId={programId} />
       <div className="mt-12">
         <ProgramDashboard programId={programId} isGuest={isGuest} />
+        {isAdmin && <div className="mt-8">hihihihi</div>}
       </div>
     </div>
   );

--- a/FE/src/components/programDetail/program/ProgramInfo.tsx
+++ b/FE/src/components/programDetail/program/ProgramInfo.tsx
@@ -8,11 +8,11 @@ import { AccessType } from "@/types/access";
 
 interface ProgramInfoProps {
   programId: number;
-  AccessType?: AccessType;
+  accessType?: AccessType;
 }
 
-const ProgramInfo = ({ programId, AccessType }: ProgramInfoProps) => {
-  const isAbleToEdit = AccessType === "admin";
+const ProgramInfo = ({ programId, accessType }: ProgramInfoProps) => {
+  const isAbleToEdit = accessType === "admin";
   const {
     data: programData,
     isLoading,
@@ -28,7 +28,7 @@ const ProgramInfo = ({ programId, AccessType }: ProgramInfoProps) => {
       <ProgramDetail
         data={programData}
         programId={programId}
-        accessType={AccessType}
+        accessType={accessType}
       />
     </section>
   );

--- a/FE/src/constants/API.ts
+++ b/FE/src/constants/API.ts
@@ -9,6 +9,7 @@ const PROGRAM = {
   ACCESS_RIGHT: (programId: number) => `/programs/${programId}/accessRight`,
   SEND_MESSAGE: (programId: number) =>
     `/programs/${programId}/slack/notification`,
+  UPDATE_ATTEND_MODE: (programId: number) => `/programs/${programId}`,
 };
 
 const MEMBER = {

--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -11,11 +11,16 @@ import {
   patchProgram,
   postProgram,
   sendSlackMessage,
+  updateProgramAttendMode,
 } from "@/apis/program";
 import API from "@/constants/API";
 import ROUTES from "@/constants/ROUTES";
 import { ActiveStatusWithAll } from "@/types/member";
-import { ProgramStatus, ProgramType } from "@/types/program";
+import {
+  ProgramAttendStatus,
+  ProgramStatus,
+  ProgramType,
+} from "@/types/program";
 
 interface CreateProgram {
   programData: PostProgramRequest;
@@ -121,5 +126,13 @@ export const useGetProgramAccessRight = (programId: number) => {
   return useQuery({
     queryKey: [API.PROGRAM.ACCESS_RIGHT(programId)],
     queryFn: () => getProgramAccessRight(programId),
+  });
+};
+
+export const useUpdateProgramAttendMode = (programId: number) => {
+  return useMutation({
+    mutationKey: [API.PROGRAM.UPDATE_ATTEND_MODE(programId)],
+    mutationFn: (attendMode: ProgramAttendStatus) =>
+      updateProgramAttendMode(programId, attendMode),
   });
 };

--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -130,9 +130,12 @@ export const useGetProgramAccessRight = (programId: number) => {
 };
 
 export const useUpdateProgramAttendMode = (programId: number) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationKey: [API.PROGRAM.UPDATE_ATTEND_MODE(programId)],
-    mutationFn: (attendMode: ProgramAttendStatus) =>
-      updateProgramAttendMode(programId, attendMode),
+    mutationFn: (attendMode: ProgramAttendStatus) => {
+      queryClient.invalidateQueries([API.PROGRAM.Edit_DETAIL(programId)]);
+      return updateProgramAttendMode(programId, attendMode);
+    },
   });
 };

--- a/FE/src/types/program.ts
+++ b/FE/src/types/program.ts
@@ -6,6 +6,7 @@ export type ProgramCategoryWithAll = ProgramCategory | "all";
 export type ProgramStatus = "active" | "end";
 export type ProgramType = "demand" | "notification";
 export type AccessRight = "edit" | "read_only";
+export type ProgramAttendStatus = "attend" | "late" | "non_open";
 
 export interface ProgramInfo {
   programId: number;
@@ -19,7 +20,7 @@ export interface ProgramInfo {
   programGithubUrl: string;
   teams: TeamInfo[];
   eventStatus: "active" | "end";
-  attend_mode: "attend" | "late" | "non_open";
+  attend_mode: ProgramAttendStatus;
 }
 
 export interface ProgramSimpleInfo extends Omit<ProgramInfo, "content"> {}


### PR DESCRIPTION
## 📌 관련 이슈
closed #50 

## ✨ PR 내용
admin 도메인에서 해당 프로그램의 상태를 변경할 수 있는 기능을 추가합니다. 

- 리팩토링
  - 반복되어 사용되는 타입을 정의하였습니다. https://github.com/JNU-econovation/EEOS-FE/commit/fe1597590f64558719ca30d2fcd6eedc734ef67a
  - 코드의 일관성을 위하여 props를 카멜케이스로 변환하였습니다. https://github.com/JNU-econovation/EEOS-FE/commit/c1b3c0c527331dea40bbbfa9172cfa7b3581ce14

- 기능
  - 각 버튼 클릭시 해당 상태로 변경할 수 있도록 modify 함수를 실행합니다.
  - 현재 출석 상태값은 기존에 프로그램 디테일 정보를 받아와 캐싱해둔 값과 useEffect를 이용한 동기화를 시켜줍니다
