### PR TITLE
[FIX] 질문 계시판에 질문 요청 api에 팀 id가 제대로 담기지 않던 버그 수정

### DIFF
--- a/FE/src/components/programDetail/program/DashboardCompound/Board/Board.tsx
+++ b/FE/src/components/programDetail/program/DashboardCompound/Board/Board.tsx
@@ -11,10 +11,11 @@ const Board = ({ isGuest = false }: BoardProps) => {
     teamValues: { selectedTeamId },
     programValue: { programId },
   } = useContext(DashboardContext);
-  const { data, isLoading } = useGetQuestion(programId, selectedTeamId);
+  const { data, isLoading, error } = useGetQuestion(programId, selectedTeamId);
 
   // TODO: Loader 적용, 에러 처리
   if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error...</div>;
 
   const { comments } = data;
 

--- a/FE/src/hooks/query/useQuestion.ts
+++ b/FE/src/hooks/query/useQuestion.ts
@@ -11,6 +11,7 @@ export const useGetQuestion = (programId: number, teamId: number) => {
   return useQuery({
     queryKey: ["question", programId, teamId],
     queryFn: () => getQuestionsByTeam(programId, teamId),
+    enabled: !!programId && (!!teamId || teamId === 0),
   });
 };
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #53 

## ✨ PR 내용
query문에 enabled 값을 사용하여 질문 계시판에서 초기 질문 요청에 teamId가 undefined인 경우 요청을 보내지 않도록 수정
