### PR TITLE
feat: 가져온 질문 데이터가 없을 경우 ui 추가 (Board.tsx)

### DIFF
--- a/FE/src/components/programDetail/program/DashboardCompound/Board/Board.tsx
+++ b/FE/src/components/programDetail/program/DashboardCompound/Board/Board.tsx
@@ -21,6 +21,11 @@ const Board = ({ isGuest = false }: BoardProps) => {
 
   return (
     <div className="flex max-h-[36rem] w-full flex-col overflow-hidden overflow-y-auto rounded-sm border">
+      {comments.length === 0 && (
+        <div className="flex h-full items-center justify-center py-20 text-xl text-gray-30">
+          아직 질문이 없습니다. 🥲
+        </div>
+      )}
       {comments.map((props) => (
         <Chat key={props.commentId} isGuest={isGuest} {...props} />
       ))}


### PR DESCRIPTION

## 📌 관련 이슈
closed #53 

## ✨ PR 내용
가져온 질문 데이터가 없을 경우 ui를 추가합니다. 

![image](https://github.com/user-attachments/assets/97ea9be7-86fc-4fb7-be4f-b2434885c4d4)



## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
