### PR TITLE
[FIX] 깃허브 url이 null 값인 경우 프론트단에서 발표자료를 보여주지 않도록 변경

### DIFF
--- a/FE/src/components/programDetail/program/ProgramDetail.tsx
+++ b/FE/src/components/programDetail/program/ProgramDetail.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useQueryClient } from "@tanstack/react-query";
 import ProgramAttendStatusManageSection from "./ProgramAttendStatusManageSection";
 import ProgramDashboard from "./ProgramDashboard";
 import ProgramPresentations from "./ProgramPresentations";
@@ -16,11 +18,15 @@ const ProgramDetail = ({ data, programId, accessType }: ProgramDetailProps) => {
   const isAdmin = accessType === "admin";
 
   const { content } = data;
+
+  const queryClient = useQueryClient();
+  const githubUrl = queryClient.getQueryData(["githubUrl", programId]);
+
   return (
     <div>
       <MarkdownViewer value={content} />
       {isAdmin && <ProgramAttendStatusManageSection programId={programId} />}
-      <ProgramPresentations programId={programId} />
+      {githubUrl && <ProgramPresentations programId={programId} />}
       <div className="mt-12">
         <ProgramDashboard programId={programId} isGuest={isGuest} />
       </div>

--- a/FE/src/hooks/query/usePresentations.ts
+++ b/FE/src/hooks/query/usePresentations.ts
@@ -3,15 +3,15 @@ import { getPresentations } from "@/apis/proxy/github";
 
 const usePresentations = (programId: number) => {
   const queryClient = useQueryClient();
+  const githubUrl = queryClient.getQueryData(["githubUrl", programId]);
   return useQuery({
     queryKey: ["presentations", programId],
     queryFn: () => {
-      const githubUrl = queryClient.getQueryData(["githubUrl", programId]);
-      if (!githubUrl) return;
       return getPresentations(githubUrl as string);
     },
     staleTime: 1000 * 60 * 60 * 24,
     cacheTime: 1000 * 60 * 60 * 24,
+    enabled: !!githubUrl,
   });
 };
 

--- a/FE/src/hooks/query/usePresentations.ts
+++ b/FE/src/hooks/query/usePresentations.ts
@@ -3,7 +3,13 @@ import { getPresentations } from "@/apis/proxy/github";
 
 const usePresentations = (programId: number) => {
   const queryClient = useQueryClient();
-  const githubUrl = queryClient.getQueryData(["githubUrl", programId]);
+  const githubUrl: string = queryClient.getQueryData(["githubUrl", programId]);
+  return useGetPresentation(programId, githubUrl);
+};
+
+export default usePresentations;
+
+const useGetPresentation = (programId: number, githubUrl: string) => {
   return useQuery({
     queryKey: ["presentations", programId],
     queryFn: () => {
@@ -14,5 +20,3 @@ const usePresentations = (programId: number) => {
     enabled: !!githubUrl,
   });
 };
-
-export default usePresentations;

--- a/FE/src/utils/github.ts
+++ b/FE/src/utils/github.ts
@@ -1,4 +1,5 @@
 export const checkIsValidateGithubUrl = (githubUrl: string) => {
+  if (!githubUrl || githubUrl == "") return false;
   const parsedUrl = new URL(githubUrl);
 
   const isGithubUrl = parsedUrl.hostname === "github.com";


### PR DESCRIPTION
## 📌 관련 이슈
closed #56 

## ✨ PR 내용
기존의 하위호환성 및 에러 상황에 따른 유저 인식을 위하여 url값이 null 인 경우 발표자료 섹션을 보여주지 않도록 변경
