### PR TITLE
fix: 명세서 변경에 따른 api 의 attend_mode 이름을 attendMode로 변경

### DIFF
--- a/FE/src/apis/dtos/program.dto.ts
+++ b/FE/src/apis/dtos/program.dto.ts
@@ -25,7 +25,7 @@ export class ProgramInfoDto {
   public readonly programStatus: ProgramStatus;
   public readonly type: ProgramType;
   public readonly accessRight: AccessRight;
-  public readonly attend_mode: ProgramAttendStatus;
+  public readonly attendMode: ProgramAttendStatus;
   public readonly programGithubUrl: string;
 
   constructor(data: ProgramInfo) {
@@ -37,7 +37,7 @@ export class ProgramInfoDto {
     this.programStatus = data?.programStatus;
     this.type = data?.type;
     this.accessRight = data?.accessRight;
-    this.attend_mode = data?.attend_mode;
+    this.attendMode = data?.attendMode;
     this.programGithubUrl = data?.programGithubUrl;
   }
 }
@@ -49,7 +49,7 @@ export class ProgramSimpleInfoDto {
   public readonly category: ProgramCategory;
   public readonly programStatus: ProgramStatus;
   public readonly type: ProgramType;
-  public readonly attend_mode: ProgramAttendStatus;
+  public readonly attendMode: ProgramAttendStatus;
 
   constructor(data: ProgramSimpleInfo) {
     this.programId = data?.programId;
@@ -58,7 +58,7 @@ export class ProgramSimpleInfoDto {
     this.category = data?.category;
     this.programStatus = data?.programStatus;
     this.type = data?.type;
-    this.attend_mode = data?.attend_mode;
+    this.attendMode = data?.attendMode;
   }
 }
 

--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -97,7 +97,7 @@ export interface PostProgramRequest
     | "programId"
     | "programStatus"
     | "accessRight"
-    | "attend_mode"
+    | "attendMode"
     | "eventStatus"
     | "teams"
   > {
@@ -165,7 +165,7 @@ export interface PatchProgramBody
     | "programId"
     | "programStatus"
     | "accessRight"
-    | "attend_mode"
+    | "attendMode"
     | "eventStatus"
     | "programGithubUrl"
     | "teams"

--- a/FE/src/components/main/ProgramListItem.tsx
+++ b/FE/src/components/main/ProgramListItem.tsx
@@ -14,7 +14,7 @@ const ProgramListItem = ({
   programData,
   contentType,
 }: ProgramListItemProps) => {
-  const { programId, title, deadLine, attend_mode } = programData;
+  const { programId, title, deadLine, attendMode } = programData;
 
   const linkUrl =
     contentType === "admin"
@@ -32,7 +32,7 @@ const ProgramListItem = ({
       <p className="w-full truncate text-center text-lg font-bold sm:text-left">
         {title}
       </p>
-      {attend_mode === "non_open" ? (
+      {attendMode === "non_open" ? (
         <p className="text-base font-normal sm:w-52">{convertDate(deadLine)}</p>
       ) : (
         // 출석체크중인 경우

--- a/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
+++ b/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
@@ -27,7 +27,7 @@ const ProgramAttendStatusManageSection = ({
   useEffect(() => {
     const currentProgramAttendStatus = queryClient.getQueryData<ProgramInfoDto>(
       [API.PROGRAM.Edit_DETAIL(programId)],
-    )?.attend_mode;
+    )?.attendMode;
     setAttendStatus(currentProgramAttendStatus);
   }, [queryClient, programId, setAttendStatus, isLoading]);
 

--- a/FE/src/types/program.ts
+++ b/FE/src/types/program.ts
@@ -20,7 +20,7 @@ export interface ProgramInfo {
   programGithubUrl: string;
   teams: TeamInfo[];
   eventStatus: "active" | "end";
-  attend_mode: ProgramAttendStatus;
+  attendMode: ProgramAttendStatus;
 }
 
 export interface ProgramSimpleInfo extends Omit<ProgramInfo, "content"> {}


### PR DESCRIPTION
## 📌 관련 이슈
closed #59 

## ✨ PR 내용
명세서가 변경됨에 따라서 attend_mode에서 attendMode로 변경

모든 api의 키는 카멜 케이스로 통일