### PR TITLE
[FIX] 회원 활동 상태 변경 body 값이 제대로 담기지 않는 버그 수정

### DIFF
--- a/FE/src/apis/member.ts
+++ b/FE/src/apis/member.ts
@@ -80,7 +80,7 @@ export const updateMemberActiveStatus = async (
   const { data } = await https({
     url: API.MEMBER.UPDATE(memberId),
     method: "PUT",
-    data: { activeStatus },
+    data: activeStatus,
   });
   return data?.data;
 };


### PR DESCRIPTION

## 📌 관련 이슈
closed #64 

## ✨ PR 내용
회원 활동 상태 변경 body 값이 제대로 담기지 않는 버그 수정
- body에 한번 더 {} 로 래핑하던 부분 제거