### PR TITLE
[FIX] 프로그램 출석 종료하기 버튼 클릭시 올바른 쿼리 스트링이 담기도록 수정

### DIFF
--- a/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
+++ b/FE/src/components/programDetail/program/ProgramAttendStatusManageSection.tsx
@@ -44,8 +44,8 @@ const ProgramAttendStatusManageSection = ({
   };
 
   const closeAttend = () => {
-    updateProgramAttendMode("non_open");
-    isSuccess && setAttendStatus("non_open");
+    updateProgramAttendMode("end");
+    isSuccess && setAttendStatus("end");
   };
 
   const startAttend = () => {

--- a/FE/src/types/program.ts
+++ b/FE/src/types/program.ts
@@ -6,7 +6,7 @@ export type ProgramCategoryWithAll = ProgramCategory | "all";
 export type ProgramStatus = "active" | "end";
 export type ProgramType = "demand" | "notification";
 export type AccessRight = "edit" | "read_only";
-export type ProgramAttendStatus = "attend" | "late" | "non_open";
+export type ProgramAttendStatus = "attend" | "late" | "non_open" | "end";
 
 export interface ProgramInfo {
   programId: number;


### PR DESCRIPTION
## 📌 관련 이슈
closed #70 

## ✨ PR 내용

기존에 종료 버튼 클릭시 non_open 값이 들어가 에러가 나던 코드를 올바르게 end 값이 들어가도록 수정

- ProgramAttendStatus 의 타입을 attend | late | non_open | end; 로 end를 추가
![image](https://github.com/user-attachments/assets/d3dae765-cd8b-4f45-85a5-f883d826e329)

