### PR TITLE
[FIX] 프로그램 아이디가 0인 경우 올바르게 요청을 보내지 못하던 버그 수정

### DIFF
--- a/FE/src/hooks/query/useQuestionQuery.ts
+++ b/FE/src/hooks/query/useQuestionQuery.ts
@@ -11,7 +11,7 @@ export const useGetQuestion = (programId: number, teamId: number) => {
   return useQuery({
     queryKey: ["question", programId, teamId],
     queryFn: () => getQuestionsByTeam(programId, teamId),
-    enabled: !!programId && (!!teamId || teamId === 0),
+    enabled: (!!programId || programId === 0) && (!!teamId || teamId === 0),
     refetchInterval: 10 * 1000,
     staleTime: 10 * 1000,
   });


### PR DESCRIPTION
## 📌 관련 이슈
closed #52 

## ✨ PR 내용
기존 !!programId  && (!!teamId || teamId === 0) 로 enable이 되어있어서 programId가 0인 경우 요청을 하지 못하던 버그
(!!programId || programId === 0) && (!!teamId || teamId === 0)로 수정하여 0일떄에도 올바르게 요청할 수 있도록 변경
