### PR TITLE
chore: 관련 이슈 추가 자동화 스크립트 작성

### DIFF
--- a/.github/hooks/prepare-commit-msg.sample
+++ b/.github/hooks/prepare-commit-msg.sample
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# 커밋 메시지 파일 경로
+commit_msg_file=$1
+
+# 현재 브랜치 이름 가져오기
+branch_name=$(git symbolic-ref --short HEAD)
+
+# 브랜치 이름에서 이슈 번호 추출하기
+issue_number=$(echo $branch_name | grep -oE '[0-9]+')
+
+# 이슈 번호가 추출되었는지 확인
+if [ -n "$issue_number" ]; then
+  # 주석을 제외한 기존 커밋 메시지 가져오기
+  message_body=$(sed '/^#/d' "$commit_msg_file")
+
+  # 새로운 메시지 작성
+  echo "$message_body\n\n#$issue_number" > "$commit_msg_file"
+fi


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
#112 

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->
커밋 메세지 푸터에 관련 이슈 번호를 자동으로 추가하는 스크립트 입니다. 

사용 방법은 아래와 같습니다.

1. 프로젝트의 루트 디렉토리에서 hooks 디렉토리 안의 prepare-commit-msg.sample 파일을 .git/hooks/prepare-commit-msg로 복사합니다
```bash
cp hooks/prepare-commit-msg.sample .git/hooks/prepare-commit-msg
```

2. 스크립트에 실행 권한을 부여합니다
```bash
chmod +x .git/hooks/prepare-commit-msg
```


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
