### PR TITLE
[FIX] 수정하기 페이지에서 수정하기시 githubUrl이 담기지 않았던 버그 수정

### DIFF
--- a/FE/src/apis/program.ts
+++ b/FE/src/apis/program.ts
@@ -139,7 +139,6 @@ export interface PatchProgramBody
     | "accessRight"
     | "attendMode"
     | "eventStatus"
-    | "programGithubUrl"
     | "teams"
   > {
   members: PatchProgramMember[];

--- a/FE/src/components/programEdit/EditForm.tsx
+++ b/FE/src/components/programEdit/EditForm.tsx
@@ -106,6 +106,7 @@ const EditForm = ({ programId }: EditFormProps) => {
         category,
         type: isDemand ? "demand" : "notification",
         teams: teamList,
+        programGithubUrl,
         members: Array.from(
           members,
           ([memberId, { beforeAttendStatus, afterAttendStatus }]) => ({

--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -46,7 +46,10 @@ export const useUpdateProgram = ({ programId }: useUpdateProgramProps) => {
 
   return useMutation({
     mutationKey: [API.PROGRAM.UPDATE(programId)],
-    mutationFn: (body: PatchProgramBody) => patchProgram({ programId, body }),
+    mutationFn: (body: PatchProgramBody) => {
+      console.log("body", body);
+      return patchProgram({ programId, body });
+    },
     onSettled: ({ programId }) => {
       router.replace(ROUTES.DETAIL(programId));
 


### PR DESCRIPTION
## 📌 관련 이슈
#115 

## ✨ PR 내용

기존에 수정하기시 githubUrl이 담기지 않던 버그가 존재하였습니다. 
request body에 해당 값이 담기지 않았다는 것을 확인하였고 추가해주었습니다!
