### PR TITLE
[FIX] 출석체크가 진행 중인 상황에서, 멤버들의 출석 상태 변경 불가능하게 구현

### DIFF
--- a/FE/src/components/programDetail/program/ProgramHeader.tsx
+++ b/FE/src/components/programDetail/program/ProgramHeader.tsx
@@ -3,6 +3,7 @@ import { ProgramInfoDto } from "@/apis/dtos/program.dto";
 import TabItem from "@/components/common/tabs/tab/TabItem";
 import Title from "@/components/common/Title/Title";
 import PROGRAM from "@/constants/PROGRAM";
+import { useGetProgramByProgramId } from "@/hooks/query/useProgramQuery";
 import { formatTimestamp } from "@/utils/convert";
 
 interface ProgramHeaderProps {
@@ -13,6 +14,11 @@ const DEADLINE_TEXT = "행사일정 : ";
 
 const ProgramHeader = ({ data }: ProgramHeaderProps) => {
   const { category, title, deadLine, programId, accessRight } = data;
+  const isAbleToEdit = accessRight === "edit";
+  const { data: programData, status } = useGetProgramByProgramId(
+    programId,
+    isAbleToEdit,
+  );
 
   const categoryText = PROGRAM.CATEGORY_TAB[category]?.text ?? "기타";
 
@@ -24,9 +30,11 @@ const ProgramHeader = ({ data }: ProgramHeaderProps) => {
         <p className="sm:text-lg">
           {DEADLINE_TEXT + formatTimestamp(deadLine)}
         </p>
-        {accessRight === "edit" && (
-          <EditAndDeleteButton programId={programId} />
-        )}
+        {(accessRight === "edit" &&
+          programData?.attendMode === "end") ||
+          (programData?.attendMode === "non_open" && (
+            <EditAndDeleteButton programId={programId} />
+          ))}
       </div>
     </section>
   );

--- a/FE/src/components/programDetail/program/ProgramHeader.tsx
+++ b/FE/src/components/programDetail/program/ProgramHeader.tsx
@@ -3,7 +3,6 @@ import { ProgramInfoDto } from "@/apis/dtos/program.dto";
 import TabItem from "@/components/common/tabs/tab/TabItem";
 import Title from "@/components/common/Title/Title";
 import PROGRAM from "@/constants/PROGRAM";
-import { useGetProgramByProgramId } from "@/hooks/query/useProgramQuery";
 import { formatTimestamp } from "@/utils/convert";
 
 interface ProgramHeaderProps {
@@ -14,11 +13,6 @@ const DEADLINE_TEXT = "행사일정 : ";
 
 const ProgramHeader = ({ data }: ProgramHeaderProps) => {
   const { category, title, deadLine, programId, accessRight } = data;
-  const isAbleToEdit = accessRight === "edit";
-  const { data: programData, status } = useGetProgramByProgramId(
-    programId,
-    isAbleToEdit,
-  );
 
   const categoryText = PROGRAM.CATEGORY_TAB[category]?.text ?? "기타";
 
@@ -30,11 +24,9 @@ const ProgramHeader = ({ data }: ProgramHeaderProps) => {
         <p className="sm:text-lg">
           {DEADLINE_TEXT + formatTimestamp(deadLine)}
         </p>
-        {(accessRight === "edit" &&
-          programData?.attendMode === "end") ||
-          (programData?.attendMode === "non_open" && (
-            <EditAndDeleteButton programId={programId} />
-          ))}
+        {accessRight === "edit" && (
+          <EditAndDeleteButton programId={programId} />
+        )}
       </div>
     </section>
   );

--- a/FE/src/components/programEdit/ParticipantStateSection.tsx
+++ b/FE/src/components/programEdit/ParticipantStateSection.tsx
@@ -1,4 +1,4 @@
-// import MemberTableWrapper from "../common/memberTable/MemberTableWrapper";
+import { useGetProgramByProgramId } from "@/hooks/query/useProgramQuery";
 import MemberActiveStatusTab from "../common/tabs/MemberActiveStatusTab";
 import AttendStateTable from "./AttendStateTable/AttendStateTable";
 
@@ -11,6 +11,16 @@ const ParticipantStateSection = ({
   programId,
   setMembers,
 }: ParticipantStateSectionProps) => {
+  const { data: programData, status } = useGetProgramByProgramId(
+    programId,
+    true,
+  );
+
+  const isEnableEdit =
+    status === "success" &&
+    programData?.attendMode !== "attend" &&
+    programData?.attendMode !== "late";
+
   return (
     <section>
       <MemberActiveStatusTab>
@@ -19,7 +29,7 @@ const ParticipantStateSection = ({
             <AttendStateTable
               programId={programId}
               selectedActive={selectedItem}
-              isEnableEdit={true}
+              isEnableEdit={isEnableEdit}
               setMembers={setMembers}
             />
           </div>

--- a/FE/src/components/programEdit/ParticipantStateSection.tsx
+++ b/FE/src/components/programEdit/ParticipantStateSection.tsx
@@ -11,15 +11,10 @@ const ParticipantStateSection = ({
   programId,
   setMembers,
 }: ParticipantStateSectionProps) => {
-  const { data: programData, status } = useGetProgramByProgramId(
-    programId,
-    true,
-  );
+  const { data: programData } = useGetProgramByProgramId(programId, true);
 
   const isEnableEdit =
-    status === "success" &&
-    programData?.attendMode !== "attend" &&
-    programData?.attendMode !== "late";
+    programData?.attendMode !== "attend" && programData?.attendMode !== "late";
 
   return (
     <section>


### PR DESCRIPTION
## 📌 관련 이슈
closed #117 

## ✨ PR 내용
출석체크가 진행 중인 상황에서, 멤버들의 출석 상태 변경 불가능하게 수정하였습니다.

출석체크를 진행하는지에 대한 확인을 위하여 해당 프로그램의 정보를 가져오는 로직이 추가되었습니다

