### PR TITLE
[CHORE] github url의 validation을 전부 백엔드로 위임

### DIFF
--- a/FE/src/components/common/form/program/CreateForm.tsx
+++ b/FE/src/components/common/form/program/CreateForm.tsx
@@ -21,7 +21,7 @@ import {
 import { useMemberSet } from "@/hooks/useMemberForm";
 import { ProgramCategory } from "@/types/program";
 import { TeamInputInfo } from "@/types/team";
-import { checkIsValidateGithubUrl } from "@/utils/github";
+// import { checkIsValidateGithubUrl } from "@/utils/github";
 
 export interface ProgramFormDataState {
   title: string;
@@ -75,12 +75,12 @@ const CreateForm = () => {
       return;
     }
 
-    const isValidGithubUrl = checkIsValidateGithubUrl(programGithubUrl);
+    // const isValidGithubUrl = checkIsValidateGithubUrl(programGithubUrl);
 
-    if (!isValidGithubUrl) {
-      toast.error("올바른 Github URL을 입력해주세요.");
-      return;
-    }
+    // if (!isValidGithubUrl) {
+    //   toast.error("올바른 Github URL을 입력해주세요.");
+    //   return;
+    // }
     const toastId = toast.loading(MESSAGE.CREATE.PENDING);
 
     createProgramMutate(

--- a/FE/src/components/programEdit/EditForm.tsx
+++ b/FE/src/components/programEdit/EditForm.tsx
@@ -24,7 +24,7 @@ import {
 import { useMemberMap } from "@/hooks/useMemberForm";
 import { ProgramCategory } from "@/types/program";
 import { TeamInputInfo } from "@/types/team";
-import { checkIsValidateGithubUrl } from "@/utils/github";
+// import { checkIsValidateGithubUrl } from "@/utils/github";
 
 const initialState: ProgramFormDataState = {
   title: "",
@@ -89,12 +89,13 @@ const EditForm = ({ programId }: EditFormProps) => {
       return;
     }
 
-    const isValidGithubUrl = checkIsValidateGithubUrl(programGithubUrl);
+    // Github URL 유효성 검사는 전부 백엔드로 위임 (#127)
+    // const isValidGithubUrl = checkIsValidateGithubUrl(programGithubUrl);
 
-    if (!isValidGithubUrl) {
-      toast.error("올바른 Github URL을 입력해주세요.");
-      return;
-    }
+    // if (!isValidGithubUrl) {
+    //   toast.error("올바른 Github URL을 입력해주세요.");
+    //   return;
+    // }
 
     const toastId = toast.loading(MESSAGE.EDIT.PENDING);
 

--- a/FE/src/utils/convert.ts
+++ b/FE/src/utils/convert.ts
@@ -25,8 +25,8 @@ export const convertText = (text: string, str: string) => {
 
 //githubUrl을 owner, repo, branch, path로 분리
 export const convertGitHubUrl = (githubUrl: string) => {
-  const isValidateGithubUrl = checkIsValidateGithubUrl(githubUrl);
-  if (!isValidateGithubUrl) throw new Error("올바르지 않은 깃허브 url입니다.");
+  // const isValidateGithubUrl = checkIsValidateGithubUrl(githubUrl);
+  // if (!isValidateGithubUrl) throw new Error("올바르지 않은 깃허브 url입니다.");
 
   const parsedUrl = new URL(githubUrl);
   const parts = parsedUrl.pathname.split("/").filter(Boolean);


### PR DESCRIPTION
## 📌 관련 이슈
closed #126 

## ✨ PR 내용
### 이전 상황
 프론트와 백엔드 모두 github url에 대하여 validation을 진행함

### 문제 상황
학기가 지나면서 기존의 validate와 맞지 않는 브랜치를 생성하게 될 수 있음. 이때 코드 변경의 비용을 줄이기 위하여 프론트에서는 해당 값에 대한 validation을 하지 않도록 함

### 변경 사항
github url의 validation로직을 주석처리

