### PR TITLE
[FEAT] member 상태에 따라 polling 적용

### DIFF
--- a/FE/src/hooks/query/useMemberQuery.ts
+++ b/FE/src/hooks/query/useMemberQuery.ts
@@ -53,6 +53,13 @@ export const useGetProgramMembersByAttend = ({
     queryKey: [API.MEMBER.ATTEND_STATUS(programId), status],
     queryFn: () => getProgramMembersByAttendStatus(programId, status),
     staleTime: 1000 * 60 * 5,
+    refetchInterval: () => {
+      if (status === "attend") {
+        return 2000;
+      } else {
+        return false;
+      }
+    },
   });
 };
 


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->
#130

## ✨ PR 내용

<!-- PR에 대한 내용을 설명해주세요. -->

- EEOS 주간발표에서 DetailPage의 참석, 지각, 불참, 미응답이 바로바로 반영되지 않는 이슈를 해결하였습니다.

### 고민

1. 실시간으로 데이터를 받아오는 방법
- WebSocket을 열면 되는거 아닌가?
    - 실시간 통신을 위해 기능 개발에 리소스 투자가 쉽지 않은 상황
1. 프론트에서 해결하자
- setInterval과 같은 기능으로 몇 초마다 요청을 받으면, 실시간처럼 보이게 할 수 있음
- 해당 부분을 쉽게 해주는 기능이 react-query의 refetchInterval

### refetchInterval

- 리액트에서 일정 간격으로 api를 호출하도록 하는 것

```
refetchInterval: number | false | ((data: TData | undefined, query: Query) => number | false)
Optional
If set to a number, all queries will continuously refetch at this frequency in milliseconds
If set to a function, the function will be executed with the latest data and query to compute a frequency

```

### EEOS에 적용하자

```tsx
export const useGetProgramMembersByAttend = ({
  programId,
  status,
}: GetProgramMemebersByAttend) => {
  return useQuery({
    queryKey: [API.MEMBER.ATTEND_STATUS(programId), status],
    queryFn: () => getProgramMembersByAttendStatus(programId, status),
    staleTime: 1000 * 60 * 5,
    refetchInterval: () => {
      if (status === "attend") {
        return 2000;
      } else {
        return false;
      }
    },
  });
};

```

### 고려한 사항

그런데, 우리는 상태가 나뉘어져 있다

- 참석
    - 참석하는 사람은 많을 것이고, 당연히 빠르게 자신의 상태가 변경되는 것을 확인하고 싶을 것이다.
- 지각
- 불참
- 미응답
    - 반대로 지각, 불참의 경우 해당하는 사람이 적을 것이고, 어차피 자신의 상태가 빠르게 변경되는 것을 확인할 필요가 없다.

### 결론

- 참석에만 refetchInterval을 설정해주자
    - 지각, 불참, 미응답은 유저에게 맡기는 방향으로 진행
    - 참석의 경우에는 빠르게 확인을 하지만 지각, 불참, 미응답의 경우에는 유저가 빠르게 실시간으로 확인할 이유도, 필요도 없다고 생각함
- @geongyu09 건규님 피드백대로, attend가 아닌 경우에는 false를 return 하도록 구현하였습니다! 감사합니다~~ 

## 주의 사항

브랜치 방향 꼭 확인하세요!!!!

### 회의 필요!

- refetchInterval을 현재 pr과 같이 계속해서 2초마다 받아오게 된다면 주간발표가 끝나게 될때까지 계속 요청이 발생 (금액적인 이슈가 발생함)
- 몇 분 동안 refetchInterval을 적용해야 하는지
- 지각, 불참, 무응답의 경우에는 refetchInterval을 적용하지 않는데, 해당 부분은 어떻게 하는 것이 좋을지