### PR TITLE
[FEAT] useGetProgramId staleTime 변경

### DIFF
--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -102,7 +102,7 @@ export const useGetProgramByProgramId = (
         );
         return res;
       }),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 60,
   });
 };
 


### PR DESCRIPTION
pollingm은 적용되었으나, admin에서 지각으로 변경해도 계속 polling이
받아와짐, 새로고침을 하면 더이상 polling이 되지 않으나 새로고침을 하지
않는 경우 주간발표가 끝날때까지 2초마다 요청 발생. 이를 해결하기 위해
useGetProgramId 의 staleTime을 5분에서 1분으로 변경

## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
