### PR TITLE
[FEAT] 멤버 상태 polling synchronicity race condition 

### DIFF
--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -85,23 +85,33 @@ export const useGetProgramByProgramId = (
   return useQuery({
     queryKey: [API.PROGRAM.Edit_DETAIL(programId)],
     queryFn: () =>
-      getProgramById(programId, isAbleToEdit).then((res) => {
-        //TODO: setquery 지양하기
-        queryClient.setQueryData<ProgramStatus>(
-          ["programStatus", programId],
-          res.programStatus,
-        );
-        queryClient.setQueryData(["attendMode", programId], res.attendMode);
-        queryClient.setQueryData<ProgramType>(
-          ["programType", programId],
-          res.type,
-        );
-        queryClient.setQueryData<string>(
-          ["githubUrl", programId],
-          res.programGithubUrl,
-        );
-        return res;
-      }),
+      getProgramById(programId, isAbleToEdit)
+        .then((res) => {
+          queryClient.cancelQueries({
+            queryKey: [API.MEMBER.ATTEND_STATUS(programId)],
+          });
+          return res;
+        })
+        .then((res) => {
+          //TODO: setquery 지양하기
+          queryClient.setQueryData<ProgramStatus>(
+            ["programStatus", programId],
+            res.programStatus,
+          );
+          queryClient.setQueryData(["attendMode", programId], res.attendMode);
+          queryClient.setQueryData<ProgramType>(
+            ["programType", programId],
+            res.type,
+          );
+          queryClient.setQueryData<string>(
+            ["githubUrl", programId],
+            res.programGithubUrl,
+          );
+          queryClient.invalidateQueries({
+            queryKey: [API.MEMBER.ATTEND_STATUS(programId)],
+          });
+          return res;
+        }),
     staleTime: 1000 * 60,
   });
 };


### PR DESCRIPTION
멤버 상태의 polling에 대한 동시성 이슈를 해결하였습니다. cancelQueries를 통해 실행중이던 useGetProgramMembersByAttend 쿼리를 최초에 취소를 하여 동시성을 해결합니다.

## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
