### PR TITLE
[FEAT] 대댓글의 대댓글 기능 추가

### DIFF
--- a/FE/src/components/feature/detail/Dashboard/components/ChatList.tsx
+++ b/FE/src/components/feature/detail/Dashboard/components/ChatList.tsx
@@ -68,9 +68,9 @@ const ChatList = ({
       deleteComment={handleDeleteComment}
       handleReply={handleReply}
       time={time}
-      updateComment={handleUpdateComment} //
+      updateComment={handleUpdateComment}
       markdownStyle={markdownStyle}
-      showReplyButton={showReplyButton} //
+      showReplyButton={showReplyButton}
     />
   );
 };

--- a/FE/src/components/feature/detail/Dashboard/components/ReplyChat.tsx
+++ b/FE/src/components/feature/detail/Dashboard/components/ReplyChat.tsx
@@ -18,7 +18,7 @@ const ReplyChat = ({
         commentId={commentId}
         accessRight={accessRight}
         markdownStyle="!bg-inherit"
-        showReplyButton={false}
+        showReplyButton={true}
       />
     </div>
   );

--- a/FE/src/hooks/query/useQuestionQuery.ts
+++ b/FE/src/hooks/query/useQuestionQuery.ts
@@ -67,16 +67,6 @@ export const usePostQuestion = () => {
         newComments,
       );
 
-      // console.log(newComments);
-
-      // console.log(
-      //   queryClient.getQueryData<QuestionListDto>([
-      //     "question",
-      //     programId,
-      //     teamId,
-      //   ]) || { comments: [] },
-      // );
-
       return oldData;
     },
     onError: (_, { programId, teamId }, oldData) => {

--- a/FE/src/utils/question.ts
+++ b/FE/src/utils/question.ts
@@ -5,31 +5,41 @@ export const makeNewQuestionData = (
   newComment: Comment,
   newCommentParentId: number,
 ): QuestionListDto => {
-  let result: QuestionListDto;
-
   // 일반 질문인 경우
   if (newCommentParentId === -1) {
     const newComments = [...prevData.comments, newComment];
-    result = {
+    return {
       comments: newComments,
     };
-    return result;
   }
 
   // 답변인 경우
   const newComments = prevData.comments.map((comment) => {
+    // 부모 댓글의 답변으로 추가
     if (comment.commentId === newCommentParentId) {
       return {
         ...comment,
         answers: [...comment.answers, newComment],
       };
     }
+
+    // 해당 comment가 부모가 아닌 경우, 해당 comment의 답변을 추가로 살펴보고 만약 대댓글이 부모인 경우
+    const isCommentOfComment = comment.answers.some((answer) => {
+      return answer.commentId === newCommentParentId;
+    });
+
+    // 대댓글의 대댓글인 경우 해당 대댓글에 추가
+    if (isCommentOfComment) {
+      return {
+        ...comment,
+        answers: [...comment.answers, newComment],
+      };
+    }
+
     return comment;
   });
 
-  result = {
+  return {
     comments: newComments,
   };
-
-  return result;
 };


### PR DESCRIPTION
## 📌 관련 이슈
closed #146 

## ✨ PR 내용
대댓글의 대댓글 기능을 추가하였습니다. 

사실 댓글과 대댓글은 같은 컴포넌트를 사용하고 있어서 showReplyButton props 하나만 값을 true로 변경해서 간단히 구현할 수 있었습니다. 
추가적으로 해당 기능이 생김에 따라서 기존에 낙관적 업데이트를 하던 부분이, 대댓글의 대댓글을 달았을 때에도 올바르게 적용되도록 util함수를 수정하였습니다

![image](https://github.com/user-attachments/assets/484ecf12-740b-480a-ac76-e48e973e8989)


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
