### PR TITLE
[FIX] 로그인과 리다이렉트 수정	

### DIFF
--- a/FE/src/apis/auth.ts
+++ b/FE/src/apis/auth.ts
@@ -1,5 +1,5 @@
 import { LoginDto } from "./dtos/auth.dto";
-import { https } from "./instance";
+import { authInstance, https } from "./instance";
 import API from "@/constants/API";
 
 /**
@@ -21,7 +21,7 @@ export const postSlackLogin = async (
  * 토큰 재발급 요청
  */
 export const postTokenReissue = async (): Promise<LoginDto> => {
-  const { data } = await https({
+  const { data } = await authInstance({
     url: API.AUTH.TOKEN_REISSUE,
     method: "POST",
   });

--- a/FE/src/apis/instance.ts
+++ b/FE/src/apis/instance.ts
@@ -19,6 +19,14 @@ const https = axios.create({
   withCredentials: true,
 });
 
+const authInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL + "/api",
+  headers: {
+    "Content-Type": "application/json",
+  },
+  withCredentials: true,
+});
+
 https.interceptors.request.use(
   async (config) => {
     if (typeof window === "undefined") return config;
@@ -34,9 +42,17 @@ https.interceptors.request.use(
     );
 
     if (timeToExpiration < TOKEN_REISSUE_THRESHOLD) {
-      const { accessToken, accessExpiredTime } = await postTokenReissue();
-      setAccessToken(accessToken);
-      setTokenExpiration(accessExpiredTime);
+      try {
+        const { accessToken, accessExpiredTime } = await postTokenReissue();
+        setAccessToken(accessToken);
+        setTokenExpiration(accessExpiredTime);
+      } catch (e) {
+        deleteTokenInfo();
+        // alert("다시 로그인해주세요 ;)");
+        // setTimeout(() => {
+        //   window.location.href = "/login";
+        // }, 3000);
+      }
     }
 
     config.headers["Authorization"] = `Bearer ${accessToken}`;
@@ -88,4 +104,4 @@ https.interceptors.response.use(
   },
 );
 
-export { https };
+export { https, authInstance };

--- a/FE/src/app/(admin)/layout.tsx
+++ b/FE/src/app/(admin)/layout.tsx
@@ -5,11 +5,12 @@ import AuthValidate from "@/components/common/validate/Auth";
 const PrivateLayout = ({ children }: PropsWithChildren) => {
   return (
     <>
-      <AuthValidate isHaveToLoggedInRoute />
-      <Header isAdmin />
-      <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
-        {children}
-      </main>
+      <AuthValidate isHaveToLoggedInRoute>
+        <Header isAdmin />
+        <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
+          {children}
+        </main>
+      </AuthValidate>
     </>
   );
 };

--- a/FE/src/app/(auth)/layout.tsx
+++ b/FE/src/app/(auth)/layout.tsx
@@ -4,8 +4,7 @@ import AuthValidate from "@/components/common/validate/Auth";
 export default function AuthLayout({ children }: PropsWithChildren) {
   return (
     <main className="mb-28 mt-16 h-full w-full max-w-[500px] sm:max-w-[800px] lg:max-w-[1112px]">
-      <AuthValidate isHaveToLoggedInRoute={false} />
-      {children}
+      <AuthValidate isHaveToLoggedInRoute={false}>{children}</AuthValidate>
     </main>
   );
 }

--- a/FE/src/app/(private)/layout.tsx
+++ b/FE/src/app/(private)/layout.tsx
@@ -5,11 +5,12 @@ import AuthValidate from "@/components/common/validate/Auth";
 const PrivateLayout = ({ children }: PropsWithChildren) => {
   return (
     <>
-      <AuthValidate />
-      <Header />
-      <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
-        {children}
-      </main>
+      <AuthValidate>
+        <Header />
+        <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
+          {children}
+        </main>
+      </AuthValidate>
     </>
   );
 };

--- a/FE/src/components/common/validate/Auth.tsx
+++ b/FE/src/components/common/validate/Auth.tsx
@@ -3,19 +3,29 @@
 import { useRouter } from "next/navigation";
 import ROUTES from "@/constants/ROUTES";
 import useAuth from "@/hooks/useAuth";
+import { PropsWithChildren } from "react";
 
-interface AuthValidateProps {
+interface AuthValidateProps extends PropsWithChildren {
   isHaveToLoggedInRoute?: boolean;
 }
 
-const AuthValidate = ({ isHaveToLoggedInRoute = true }: AuthValidateProps) => {
+const AuthValidate = ({
+  isHaveToLoggedInRoute = true,
+  children,
+}: AuthValidateProps) => {
   const router = useRouter();
   const { isLoggedIn, isLoading } = useAuth();
 
   if (isLoading) return null;
-  if (isHaveToLoggedInRoute && !isLoggedIn) router.push(ROUTES.LOGIN);
-  if (!isHaveToLoggedInRoute && isLoggedIn) router.push(ROUTES.MAIN);
+  if (isHaveToLoggedInRoute && !isLoggedIn) {
+    router.push(ROUTES.LOGIN);
+    return null;
+  }
+  if (!isHaveToLoggedInRoute && isLoggedIn) {
+    router.push(ROUTES.MAIN);
+    return null;
+  }
 
-  return <></>;
+  return <>{children}</>;
 };
 export default AuthValidate;

--- a/FE/src/components/feature/detail/Dashboard/components/DashboardInput.tsx
+++ b/FE/src/components/feature/detail/Dashboard/components/DashboardInput.tsx
@@ -2,7 +2,6 @@
 
 import { PostQuestionParams } from "@/apis/question";
 import CheckBox from "@/components/common/CheckBox/CheckBox";
-import StatusToggleItem from "@/components/common/StatusToggleItem";
 import { Send } from "@/components/icons";
 import { usePostQuestion } from "@/hooks/query/useQuestionQuery";
 import { useGetAccessType } from "@/hooks/useAccess";

--- a/FE/src/constants/ERROR_CODE.ts
+++ b/FE/src/constants/ERROR_CODE.ts
@@ -26,6 +26,7 @@ const ERROR_CODE = {
     NO_ACCESS_TOKEN: "4000",
     EXPIRED_ACCESS_TOKEN: "4001",
     NOT_EXIST_OAUTH_SERVER: "4002",
+    INVALID_TOKEN: "4003",
     NO_REFRESH_TOKEN: "4004",
     EXPIRED_REFRESH_TOKEN: "4005",
     INVALID_NAME: "4006",
@@ -37,7 +38,7 @@ const ERROR_CODE = {
     NOT_JOINABLE: "6003",
     COMPLETED: "6010",
   },
-};
+} as const;
 
 Object.freeze(ERROR_CODE);
 

--- a/FE/src/constants/ERROR_MESSAGE.ts
+++ b/FE/src/constants/ERROR_MESSAGE.ts
@@ -74,6 +74,9 @@ const ERROR_MESSAGE = {
   [ERROR_CODE.AUTH.EXPIRED_REFRESH_TOKEN]: {
     message: "로그인이 필요합니다.",
   },
+  [ERROR_CODE.AUTH.INVALID_TOKEN]: {
+    message: "로그인이 필요합니다.",
+  },
   [ERROR_CODE.AUTH.INVALID_NAME]: {
     message:
       "에코노베이션 슬랙의 표시 이름 형식이 올바르지 않습니다. (예: 25기 홍길동)",

--- a/FE/src/hooks/useAuth.tsx
+++ b/FE/src/hooks/useAuth.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { CheckIsLoggedIn } from "@/utils/authWithStorage";
 
 /**
  * 토큰값을 확인하여 로그인 여부를 반환하는 hook
+ *
  * isLoggedIn이 true일 경우 로그인이 되어있는 상태이며, false일 경우 로그인이 되어있지 않은 상태이다.
  * isLoading이 true일 경우 토큰값을 확인하는 중이며, false일 경우 토큰값 확인이 완료된 상태이다.
  *
@@ -13,7 +14,7 @@ const useAuth = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const isLoggedIn = CheckIsLoggedIn();
     setIsLoggedIn(isLoggedIn);
     setIsLoading(false);


### PR DESCRIPTION
#21 
## 📌 관련 이슈
closed #21 

### 문제 상황 1
기존에는 로그인 여부에 따라 리다이렉트 로직이 존재하여도, 빌드타임에 정적으로 만들어진 html을 다운 받고, js가 렌더링되기 전까지의 시간동안 확인을 하면 안되는 화면을 사용자가 보게되는 문제가 존재함.

![Jan-20-2025 22-51-38](https://github.com/user-attachments/assets/7cdf0808-8abe-4b2d-951d-6274e7806027)

![Jan-20-2025 22-49-01](https://github.com/user-attachments/assets/28be67ab-a8ae-42be-b254-2f3d53ea49dc)

이는 기존에 layout.tsx에 토큰검사를 하는 컴포넌트를 하나 만들어 두어 로그인 여부에 따라서 접근을 막고 리다이렉트를 시키는 방식으로 구현되어있었음.

```
// layout.tsx

const PrivateLayout = ({ children }: PropsWithChildren) => {
  return (
    <>
      {/* AuthValidate가 로그인 여부에 따른 리다이렉트를 수행하는 컴포넌트 */}
      <AuthValidate />
      <Header />
      <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
        {children}
      </main>
    </>
  );
};
export default PrivateLayout;

```
```
// AuthValidate.tsx
"use client";

import { useRouter } from "next/navigation";
import ROUTES from "@/constants/ROUTES";
import useAuth from "@/hooks/useAuth";

interface AuthValidateProps {
  isHaveToLoggedInRoute?: boolean;
}

const AuthValidate = ({ isHaveToLoggedInRoute = true }: AuthValidateProps) => {
  const router = useRouter();
  const { isLoggedIn, isLoading } = useAuth();

// validate에 따라서 리다이렉트를 수행한다.

  if (isLoading) return null;
  if (isHaveToLoggedInRoute && !isLoggedIn) router.push(ROUTES.LOGIN);
  if (!isHaveToLoggedInRoute && isLoggedIn) router.push(ROUTES.MAIN);

// 아무런 렌더링 결과를 가지지 않는다. 
  return <></>;
};
export default AuthValidate;
```

하지만 이는 토큰을 확인하기 위해서 window가 존재하는 환경에서 돌아가는 로직이었고, 이로 인해서 next의 빌드 시간대에 만들어지는 html 렌더링 결과물에는 해당 내용이 들어가버리는 문제가 존재했다.
이로 인해서 js가 브라우저에서 hydrate되기 전에 해당 내용을 확인할 수 있게 되는 문제가 존재했다.

### 해결 1
이를 해결하기 위해서 로그인 여부에 따라서 chidlren을 조건부로 렌더링하도록 만들고, 실제 내용물을 children에 넣어두어 빌드타임에 해당 내용이 렌더링되는 것을 막고, js로 완전히 로그인 여부를 확인할 수 있을 때, 그리고 올바른 사용자일때 렌더링이 되도록 수정하였다.

```
const AuthValidate = ({
  isHaveToLoggedInRoute = true,
  children,
}: AuthValidateProps) => {
  const router = useRouter();
  const { isLoggedIn, isLoading } = useAuth();

  if (isLoading) return null;
  if (isHaveToLoggedInRoute && !isLoggedIn) {
    router.push(ROUTES.LOGIN);
    return null;
  }
  if (!isHaveToLoggedInRoute && isLoggedIn) {
    router.push(ROUTES.MAIN);
    return null;
  }

  return <>{children}</>;
};
export default AuthValidate;
```
```
//layout.tsx
const PrivateLayout = ({ children }: PropsWithChildren) => {
  return (
    <>
      <AuthValidate>
        <Header />
        <main className="my-16 w-full px-3 sm:max-w-[800px] lg:max-w-[1112px]">
          {children}
        </main>
      </AuthValidate>
    </>
  );
};
export default PrivateLayout;
```
[해결 후]

![Jan-20-2025 23-28-43](https://github.com/user-attachments/assets/b86a1040-f012-4eb8-8925-57de5714d15e)

![Jan-20-2025 23-31-57](https://github.com/user-attachments/assets/6013aa1d-a5a9-4f9a-89e7-18cd69e4ff74)

### 문제 상황 2

기존에 로그인 유지를 위하여 토큰 만료 시간에 가까워지면 reissue를 통하여 다시 토큰을 가져오도록 하고있었다. 
해당 로직은 일반적으로 사용하고 있던 axios 인스턴스의 인터셉터에 정의되어있었다. 
여기에서 reissue또한 해당 인스턴스를 사용하면서 reissue에서 에러 발생시 무한 루프에 걸리게 되며, 이로 인해서 메모리 초과로 서비스가 죽어버리는 문제 발생

### 해결 2
이를 해결하기 위해서 reissue 요청에서는 다른 인스턴스를 사용하여 reissue요청에서 reissue요청을 하지 않도록 수정

## 남은 구현 사항
토큰을 가져오는 다른 axios문또한 다른 인스턴스를 사용하여도 괜찮은지 백엔드와 논의 필요
