### PR TITLE
[CHORE] 로그인 플로우 변경에 따른 Slack OAuth 요청 url 수정

### DIFF
--- a/FE/src/components/feature/login/default/SlackLoginBtn.tsx
+++ b/FE/src/components/feature/login/default/SlackLoginBtn.tsx
@@ -1,14 +1,14 @@
+import { useSlackLoginMutation } from "@/hooks/query/useAuthQuery";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import StyledLinkButton from "../../../common/Button/StyledLinkButton";
-import { useSlackLoginMutation } from "@/hooks/query/useAuthQuery";
 
 const SlackLoginBtn = () => {
   const clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID;
   const redirectUri = process.env.NEXT_PUBLIC_SLACK_REDIRECT_URI;
   const teamId = process.env.NEXT_PUBLIC_SLACK_TEAM_ID;
 
-  const slackLoginUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&team_id=${teamId}&scope=&user_scope=users.profile:read&redirect_uri=${redirectUri}`;
+  const slackLoginUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&team_id=${teamId}&scope=&user_scope=users.profile:read&redirect_uri=${redirectUri}&prompt=none`;
 
   const searchParams = useSearchParams();
   const code = searchParams.get("code");

--- a/FE/src/hooks/query/useAuthQuery.ts
+++ b/FE/src/hooks/query/useAuthQuery.ts
@@ -1,5 +1,3 @@
-import { useMutation } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 import { postAdminLogin, postSlackLogin } from "@/apis/auth";
 import ERROR_CODE from "@/constants/ERROR_CODE";
 import ROUTES from "@/constants/ROUTES";
@@ -8,15 +6,16 @@ import {
   setAccessToken,
   setTokenExpiration,
 } from "@/utils/authWithStorage";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 
 // TODO: 라우팅 및 토큰 처리 로직은 컴포넌트에서 수행
 export const useSlackLoginMutation = () => {
   const router = useRouter();
   return useMutation(
     ["slackLogin"],
-    async ({ code, redirect_uri }: { code: string; redirect_uri: string }) => {
-      return await postSlackLogin(code, redirect_uri);
-    },
+    async ({ code, redirect_uri }: { code: string; redirect_uri: string }) =>
+      await postSlackLogin(code, redirect_uri),
     {
       onSuccess: (data) => {
         const { accessToken, accessExpiredTime } = data;


### PR DESCRIPTION
## 📌 관련 이슈
closed #169 

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

기존에 로그인을 했었던 사용자라면 로그인 중 slack 페이지에서 권한 요청 절차를 하지 않도록 OAuth 요청 url의 propt값을 none으로 수정


## 특이사항

해당 값이 올바르게 적용되는지에 대한 여부를 개발용에서 확인 후 해당 이슈를 닫도록 하겠습니다.
