### PR TITLE
[FIX] 기존에 guest요청과 admin 요청이 동일한 key로 캐싱이 되어 올바르게 edit 권한을 확인하지 못하는 버그 수정

### DIFF
--- a/FE/src/components/feature/detail/Dashboard/TeamsTab.tsx
+++ b/FE/src/components/feature/detail/Dashboard/TeamsTab.tsx
@@ -4,6 +4,7 @@ import Tab from "@/components/common/tabs/tab/TabCompound/TabCompound";
 import { Hyperlink, HyperlinkGray } from "@/components/icons";
 import usePresentations from "@/hooks/query/usePresentations";
 import { useTeamQuery } from "@/hooks/query/useTeamQuery";
+import { useGetAccessType } from "@/hooks/useAccess";
 import Link from "next/link";
 
 interface SelectedItemProps {

--- a/FE/src/hooks/query/usePresentations.ts
+++ b/FE/src/hooks/query/usePresentations.ts
@@ -3,7 +3,7 @@ import { getPresentations } from "@/apis/proxy/github";
 import { useGetProgramByProgramId } from "./useProgramQuery";
 
 const usePresentations = (programId: number) => {
-  const { data: programData } = useGetProgramByProgramId(programId);
+  const { data: programData } = useGetProgramByProgramId(programId, false);
   return useGetPresentation(programId, programData?.programGithubUrl);
 };
 

--- a/FE/src/hooks/query/useProgramQuery.ts
+++ b/FE/src/hooks/query/useProgramQuery.ts
@@ -77,12 +77,12 @@ export const useDeleteProgram = () => {
 
 export const useGetProgramByProgramId = (
   programId: number,
-  isAbleToEdit: boolean = false,
+  isAbleToEdit: boolean,
 ) => {
   const queryClient = useQueryClient();
 
   return useQuery({
-    queryKey: [API.PROGRAM.Edit_DETAIL(programId)],
+    queryKey: [API.PROGRAM.Edit_DETAIL(programId), isAbleToEdit],
     queryFn: () =>
       getProgramById(programId, isAbleToEdit)
         .then((res) => {


### PR DESCRIPTION
#186

## 📌 관련 이슈
closed #186 

## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

기존에 guest요청과 admin 요청이 동일한 key로 캐싱이 되어 한 페이지 내에서 각각의 요청이 동시에 요청시 이후에 온 응답값을 사용하게 되던 문제가 존재하였습니다. 
각각의 요청을 다른 key로 캐싱하도록 하여 해결하였습니다

## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
