### PR TITLE
[HOTFIX] 질문게시판에서 팀과 링크가 올바르게 매핑되지 않던 버그 수정

### DIFF
--- a/FE/src/components/feature/detail/Dashboard/TeamsTab.tsx
+++ b/FE/src/components/feature/detail/Dashboard/TeamsTab.tsx
@@ -4,7 +4,6 @@ import Tab from "@/components/common/tabs/tab/TabCompound/TabCompound";
 import { Hyperlink, HyperlinkGray } from "@/components/icons";
 import usePresentations from "@/hooks/query/usePresentations";
 import { useTeamQuery } from "@/hooks/query/useTeamQuery";
-import { useGetAccessType } from "@/hooks/useAccess";
 import Link from "next/link";
 
 interface SelectedItemProps {
@@ -16,6 +15,7 @@ interface TeamsTabProps {
   programId: number;
   children: (selectedItem: SelectedItemProps) => JSX.Element;
 }
+
 const TeamsTab = ({ programId, children }: TeamsTabProps) => {
   const { data: teamsQueryData } = useTeamQuery(programId);
   const { data: presentation } = usePresentations(programId);
@@ -35,32 +35,33 @@ const TeamsTab = ({ programId, children }: TeamsTabProps) => {
       tabSize="md"
     >
       <Tab.List className="!gap-0 border-b">
-        {teamNameArray.map((name, index) => (
-          <Tab.NakedItem key={`${name}-${index}`} text={name} value={name}>
-            {presentation?.find(
-              ({ name: presentationItemName }) => presentationItemName === name,
-            )?.download_url ? (
-              <Link
-                href={
-                  presentation?.find(
-                    ({ name: presentationItemName }) =>
-                      presentationItemName === name,
-                  )?.download_url
-                    ? presentation.find(({ name }) => name === name)
-                        .download_url
-                    : "#!"
-                }
-                target="_blank"
-              >
-                <Hyperlink />
-              </Link>
-            ) : (
-              <div className="cursor-not-allowed">
-                <HyperlinkGray />
-              </div>
-            )}
-          </Tab.NakedItem>
-        ))}
+        {teamNameArray.map((teamName, index) => {
+          // 해당 팀 이름에 맞는 presentation 항목 찾기
+          const teamPresentation = presentation?.find(
+            (item) => item.name === teamName,
+          );
+
+          const downloadUrl = teamPresentation?.download_url || "#!";
+          const hasDownloadUrl = !!teamPresentation?.download_url;
+
+          return (
+            <Tab.NakedItem
+              key={`${teamName}-${index}`}
+              text={teamName}
+              value={teamName}
+            >
+              {hasDownloadUrl ? (
+                <Link href={downloadUrl} target="_blank">
+                  <Hyperlink />
+                </Link>
+              ) : (
+                <div className="cursor-not-allowed">
+                  <HyperlinkGray />
+                </div>
+              )}
+            </Tab.NakedItem>
+          );
+        })}
       </Tab.List>
       <Tab.Content<string>>
         {({ selectedItem }) =>


### PR DESCRIPTION
## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

질문게시판에서 팀과 링크가 올바르게 매핑되지 않던 버그를 수정하였습니다.

원인 :
기존에 인자의 중복된 식별자를 사용함에 따라서 올바른 식별자가 참조되지 않는 휴먼 에러가 발생하였습니다. 

수정 :
식별자 이름을 다르게 사용하도록 수정하였습니다. 
