### PR TITLE
[FEAT]  행사 시작 시간을 시/분까지 입력받을 수 있도록 구현

### DIFF
--- a/FE/src/components/common/calendar/Calendar.tsx
+++ b/FE/src/components/common/calendar/Calendar.tsx
@@ -1,23 +1,51 @@
 import { DayPicker } from "react-day-picker";
 import "react-day-picker/dist/style.css";
 import "./calendar.styles.css";
+import { useState } from "react";
 
 interface CalendarProps {
   date: Date | undefined;
+  withTime?: boolean;
   handleDateChange: (date: Date | undefined) => void;
 }
 
-const Calendar = ({ date, handleDateChange }: CalendarProps) => {
+const Calendar = ({ date, withTime, handleDateChange }: CalendarProps) => {
   const disabledDays = { before: new Date() };
 
+  const [timeValue, setTimeValue] = useState<string>("00:00");
+
   return (
-    <DayPicker
-      mode="single"
-      selected={date}
-      onSelect={handleDateChange}
-      disabled={disabledDays}
-      className="absolute left-0 top-[4.5rem] z-10 rounded-md bg-background p-3 shadow-md"
-    />
+    <div className="absolute left-0 top-[4.5rem] z-10 rounded-md bg-background p-3 shadow-md">
+      <DayPicker
+        mode="single"
+        selected={date}
+        onSelect={(e) => {
+          handleDateChange(e);
+        }}
+        disabled={disabledDays}
+      />
+      {withTime && (
+        <>
+          <form style={{ marginBlockEnd: "1em" }}>
+            <label>
+              Set the time:{" "}
+              <input
+                type="time"
+                value={timeValue}
+                onChange={(e) => {
+                  const [hours, minutes] = e.target.value.split(":");
+                  const newDate = date ? new Date(date) : new Date();
+                  newDate.setHours(parseInt(hours, 10));
+                  newDate.setMinutes(parseInt(minutes, 10));
+                  handleDateChange(newDate);
+                  setTimeValue(e.target.value);
+                }}
+              />
+            </label>
+          </form>
+        </>
+      )}
+    </div>
   );
 };
 export default Calendar;

--- a/FE/src/components/common/calendar/Calendar.tsx
+++ b/FE/src/components/common/calendar/Calendar.tsx
@@ -25,25 +25,24 @@ const Calendar = ({ date, withTime, handleDateChange }: CalendarProps) => {
         disabled={disabledDays}
       />
       {withTime && (
-        <>
-          <form style={{ marginBlockEnd: "1em" }}>
-            <label>
-              Set the time:{" "}
-              <input
-                type="time"
-                value={timeValue}
-                onChange={(e) => {
-                  const [hours, minutes] = e.target.value.split(":");
-                  const newDate = date ? new Date(date) : new Date();
-                  newDate.setHours(parseInt(hours, 10));
-                  newDate.setMinutes(parseInt(minutes, 10));
-                  handleDateChange(newDate);
-                  setTimeValue(e.target.value);
-                }}
-              />
-            </label>
-          </form>
-        </>
+        <div className="flex items-center justify-center gap-2 border-t pt-2">
+          <label htmlFor="time-input" className="font-semibold">
+            행사 시작 시간 :{" "}
+          </label>
+          <input
+            id="time-input"
+            type="time"
+            value={timeValue}
+            onChange={(e) => {
+              const [hours, minutes] = e.target.value.split(":");
+              const newDate = date ? new Date(date) : new Date();
+              newDate.setHours(parseInt(hours, 10));
+              newDate.setMinutes(parseInt(minutes, 10));
+              handleDateChange(newDate);
+              setTimeValue(e.target.value);
+            }}
+          />
+        </div>
       )}
     </div>
   );

--- a/FE/src/components/common/form/program/ProgramDate.tsx
+++ b/FE/src/components/common/form/program/ProgramDate.tsx
@@ -9,6 +9,7 @@ import { ProgramFormDataState } from "./CreateForm";
 import FORM_INFO from "@/constants/FORM_INFO";
 import useOutsideRef from "@/hooks/useOutsideRef";
 import { formatTimestamp } from "@/utils/convert";
+import LabeldInputFiled from "../input/LabeldInputFiled";
 
 // const Calendar = dynamic(() => import("@/components/common/Calendar/Calendar"));
 
@@ -37,24 +38,27 @@ const ProgramDate = ({ getValues, setValue }: ProgramDateProps) => {
   };
 
   return (
-    <div
-      onClick={handleCalenderOpen}
-      className="relative w-full"
-      ref={calenderRef}
-    >
-      <LabeledInput
-        id={FORM_INFO.PROGRAM.DATE.id}
-        type={FORM_INFO.PROGRAM.DATE.type}
-        label={FORM_INFO.PROGRAM.DATE.label}
-        placeholder={FORM_INFO.PROGRAM.DATE.placeholder}
-        value={formatTimestamp(getValues("deadLine"))}
-      />
-      {openCalender && (
-        <Calendar
-          date={date}
-          handleDateChange={(date: Date) => handleDateChange(date)}
+    <div className="flex w-full flex-col gap-4">
+      <div
+        onClick={handleCalenderOpen}
+        className="relative w-full"
+        ref={calenderRef}
+      >
+        <LabeledInput
+          id={FORM_INFO.PROGRAM.DATE.id}
+          type={FORM_INFO.PROGRAM.DATE.type}
+          label={FORM_INFO.PROGRAM.DATE.label}
+          placeholder={FORM_INFO.PROGRAM.DATE.placeholder}
+          value={formatTimestamp(getValues("deadLine"), "full")}
         />
-      )}
+        {openCalender && (
+          <Calendar
+            date={date}
+            handleDateChange={(date: Date) => handleDateChange(date)}
+            withTime
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/FE/src/components/feature/detail/program/ProgramHeaderSection.tsx
+++ b/FE/src/components/feature/detail/program/ProgramHeaderSection.tsx
@@ -35,7 +35,7 @@ const ProgramHeaderSection = () => {
       <Title text={title} />
       <div className="flex justify-between">
         <p className="sm:text-lg">
-          {DEADLINE_TEXT + formatTimestamp(deadLine)}
+          {DEADLINE_TEXT + formatTimestamp(deadLine, "full")}
         </p>
         {accessRight === "edit" && <EditAndDeleteButton />}
       </div>

--- a/FE/src/components/main/ProgramListItem.tsx
+++ b/FE/src/components/main/ProgramListItem.tsx
@@ -37,8 +37,8 @@ const ProgramListItem = ({
       {isOnChecking ? (
         <ProgressDisplay progressText="출석 진행중" color="success" />
       ) : (
-        <p className="text-base font-normal sm:w-52">
-          {formatTimestamp(deadLine)}
+        <p className="shrink-0 text-base font-normal sm:w-64 ">
+          {formatTimestamp(deadLine, "full")}
         </p>
       )}
     </Link>

--- a/FE/src/utils/convert.ts
+++ b/FE/src/utils/convert.ts
@@ -4,17 +4,26 @@ const WEEK = ["일", "월", "화", "수", "목", "금", "토"];
 
 export const formatTimestamp = (
   timestamp: string,
-  type: "default" | "short" = "default",
+  type: "default" | "short" | "full" = "default",
 ) => {
   const date = new Date(parseInt(timestamp));
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const day = date.getDate().toString().padStart(2, "0");
   const dayOfWeek = WEEK[date.getDay()];
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
 
-  return type === "default"
-    ? `${year}년 ${month}월 ${day}일 (${dayOfWeek})`
-    : `${year}-${month}-${day} (${dayOfWeek})`;
+  switch (type) {
+    case "default":
+      return `${year}년 ${month}월 ${day}일 (${dayOfWeek})`;
+    case "short":
+      return `${year}-${month}-${day} (${dayOfWeek})`;
+    case "full":
+      return `${year}년 ${month}월 ${day}일 (${dayOfWeek}) ${hours}시 ${minutes}분`;
+    default:
+      return `${year}년 ${month}월 ${day}일 (${dayOfWeek})`;
+  }
 };
 
 // text에서 문자열 제거
@@ -25,7 +34,6 @@ export const convertText = (text: string, str: string) => {
 
 //githubUrl을 owner, repo, branch, path로 분리
 export const convertGitHubUrl = (githubUrl: string) => {
-
   //TODO: 백엔드에서 유효성 검사하도록 수정. 백엔드와 논의 필요
   // const isValidateGithubUrl = checkIsValidateGithubUrl(githubUrl);
   const isValidateGithubUrl = true;


### PR DESCRIPTION
## 📌 관련 이슈
closed #190

## ✨ PR 내용

회장단에서 요구했던 행사 시작 시간을 시/분까지 입력받을 수 있게 변경하였습니다. 

<div align="center">
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/1c70dc2b-1bd2-4374-a4a2-c4c3a6ce609f" />
</div>

기존에 존재하던 Calendar 컴포넌트를 수정하여 withTime Props을 준 경우 하단에 시간까지 입력받을 수 있는 input이 보이도록 수정하였습니다. 

convert.ts의 formatTimestamp함수에서 시/분까지 포맷할 수 있는 'full' 타입을 추가하였습니다. 
이를 통해서 행사의 일정을 보여줄 때 시간과 함께 보여주도록 수정하였습니다. 

<div align="center">
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/b38366a1-eb48-487b-8a5e-1698af45a3a8" />
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/69e6473b-a77f-4070-8919-70ff50c005a0" />
</div>