### PR TITLE
[FIX] 달력 페이지에서 선택한 행사의 관련 url이 보이지 않는 버그 수정

### DIFF
--- a/FE/src/apis/dtos/calendar.dto.ts
+++ b/FE/src/apis/dtos/calendar.dto.ts
@@ -4,6 +4,7 @@ export class SimpleCalendarDto {
   public startAt: number;
   public endAt: number;
   public type: "event" | "presentation" | "etc";
+  public url: string;
 
   constructor(data: {
     calendarId: number;
@@ -11,11 +12,13 @@ export class SimpleCalendarDto {
     startAt: number;
     endAt: number;
     type: "event" | "presentation" | "etc";
+    url: string;
   }) {
     this.calendarId = data.calendarId;
     this.title = data.title;
     this.startAt = data.startAt;
     this.endAt = data.endAt;
     this.type = data.type;
+    this.url = data.url;
   }
 }

--- a/FE/src/components/calendar/EventInfoModal.tsx
+++ b/FE/src/components/calendar/EventInfoModal.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Calendar } from "@/types/calendar";
+import Link from "next/link";
 
 interface Props {
   event: Calendar;
@@ -66,14 +67,14 @@ export function EventInfoModal({ event, closeModal, onDeleteEvent }: Props) {
               <h3 className="mb-1 text-sm font-medium text-gray-700">
                 관련 Slack 링크
               </h3>
-              <a
+              <Link
                 href={event.url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="break-all text-blue-600 underline hover:text-blue-800"
               >
                 {event.url}
-              </a>
+              </Link>
             </div>
           )}
 


### PR DESCRIPTION
## ✨ PR 내용

달력 페이지에서 선택한 행사의 관련 url이 보이지 않는 버그를 수정하였습니다.
