### PR TITLE
[FEAT] 공지사항 탭 구현

### DIFF
--- a/FE/apps/native/app.config.ts
+++ b/FE/apps/native/app.config.ts
@@ -11,6 +11,7 @@ const config = {
     ios: {
       supportsTablet: true,
       bundleIdentifier: "com.blackcompany.eeos",
+      appleTeamId: "3XD9F9256D",
       googleServicesFile: "./GoogleService-Info.plist",
       entitlements: {
         "aps-environment": "production",

--- a/FE/apps/native/app.config.ts
+++ b/FE/apps/native/app.config.ts
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   expo: {
     name: "eeos",
     slug: "eeos",
@@ -10,7 +10,7 @@ module.exports = {
     newArchEnabled: true,
     ios: {
       supportsTablet: true,
-      bundleIdentifier: "com.geongyu09.xnative",
+      bundleIdentifier: "com.blackcompany.eeos",
       googleServicesFile: "./GoogleService-Info.plist",
       entitlements: {
         "aps-environment": "production",
@@ -33,7 +33,7 @@ module.exports = {
       googleServicesFile: "./google-services.json",
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
-      package: "com.geongyu09.xnative",
+      package: "com.blackcompany.eeos",
       // 웹뷰에서 http 도메인 허용. 빌드시에는 https로 변경 혹은 특정 도메인만 허용하도록 수정 필요
       usesCleartextTraffic: true,
       useNextNotificationsApi: true, // FCM을 위한 설정
@@ -80,8 +80,10 @@ module.exports = {
     },
     extra: {
       eas: {
-        projectId: "05949d1e-7d4a-4649-b8d7-84e37126e5a7",
+        projectId: "1cccc629-7c0b-4613-8646-e507982e2908",
       },
     },
   },
 };
+
+export default config;

--- a/FE/apps/web/src/apis/announcement.ts
+++ b/FE/apps/web/src/apis/announcement.ts
@@ -1,0 +1,16 @@
+import API from "@/constants/API";
+import { AnnouncementDto } from "./dtos/announcement";
+import { https } from "./instance";
+
+/**
+ * 모바일 홈 화면에서 사용하는 공지사항 가져오기 요청
+ */
+export const getAnnouncements = async (): Promise<AnnouncementDto[]> => {
+  const { data } = await https({
+    url: API.ANNOUNCEMENT.LIST,
+    method: "GET",
+  });
+  return (data?.data.announcements || []).map(
+    (item: any) => new AnnouncementDto(item),
+  );
+};

--- a/FE/apps/web/src/apis/dtos/announcement.ts
+++ b/FE/apps/web/src/apis/dtos/announcement.ts
@@ -1,0 +1,24 @@
+export class AnnouncementDto {
+  public readonly id: number;
+  public readonly title: string;
+  public readonly body: string;
+  public readonly announcedAt: number;
+  public readonly deadline: number;
+  public readonly createdDate: number;
+
+  constructor(data: {
+    id: number;
+    title: string;
+    body: string;
+    announcedAt: number;
+    deadline: number;
+    createdDate: number;
+  }) {
+    this.id = data?.id;
+    this.title = data?.title;
+    this.body = data?.body;
+    this.announcedAt = data?.announcedAt;
+    this.deadline = data?.deadline;
+    this.createdDate = data?.createdDate;
+  }
+}

--- a/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
@@ -5,7 +5,6 @@ import AnnouncementSection from "@/components/feature/webview-main/AnnouncementS
 import HelloSection from "@/components/feature/webview-main/HelloSection";
 import HomeEventSection from "@/components/feature/webview-main/HomeEventSection";
 import { SsgoiTransition } from "@ssgoi/react";
-// import UserMetaSection from "@/components/feature/webview-main/UserMetaSection";
 
 const WebviewMainPage = () => {
   return (
@@ -28,6 +27,9 @@ const WebviewMainPage = () => {
         <div className="grow px-6 shadow-[0px_-100px_10px_0px_rgba(34,43,69,0.21)]">
           <Spacing size={32} direction="vertical" unit="px" />
           <AnnouncementSection />
+        </div>
+        <div>
+          <Spacing size={32} direction="vertical" unit="px" />
         </div>
       </div>
     </SsgoiTransition>

--- a/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
@@ -1,17 +1,70 @@
+"use client";
+
+import Spacing from "@/components/common/Spacing";
+import { useAnnouncementsQuery } from "@/hooks/query/useAnnouncementsQuery";
+import { useState } from "react";
+
 const AnnouncementSection = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data: announcements, isLoading, error } = useAnnouncementsQuery();
+
+  if (isLoading || !announcements) {
+    return <p>공지사항을 불러오는 중입니다...</p>;
+  }
+
+  if (error) {
+    return <p>공지사항을 불러오는 중 오류가 발생했습니다.</p>;
+  }
+
   return (
     <section>
       <p className="text-xs font-medium text-[#767676]">일정 리마인드</p>
       <h2 className="text-lg font-semibold">에코노베이션 공지사항</h2>
+      <Spacing size={0.75} direction="vertical" />
       <ul className="flex flex-col gap-2">
-        {/* <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 1</li>
-        <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 2</li>
-        <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 3</li> */}
-        <div className="rounded-xl bg-[#F2F2F7] p-4 text-sm">
-          <p>조만간 기능이 업데이트 될 예정입니다.</p>
-          <p>조금만 기다려주세요! 😊</p>
-        </div>
+        {announcements.map(({ id, title, body, announcedAt }) => (
+          <li key={id} className="gap-4 rounded-lg bg-[#F2F2F7] p-3">
+            <div className="flex items-center gap-1">
+              {!isOpen && (
+                <p className="shrink-0 text-sm font-medium">
+                  {new Date(announcedAt).toLocaleDateString("ko-KR", {
+                    month: "2-digit",
+                    day: "2-digit",
+                  })}
+                </p>
+              )}
+              <h3 className="font-medium">{title}</h3>
+            </div>
+
+            {isOpen && (
+              <>
+                <Spacing size={20} unit="px" direction="vertical" />
+                <p className="text-sm text-[#767676]">{body}</p>
+                <div>
+                  <Spacing size={20} unit="px" direction="vertical" />
+                  <p className="text-right text-xs text-[#767676]">
+                    {new Date(announcedAt).toLocaleDateString("ko-KR", {
+                      year: "numeric",
+                      month: "2-digit",
+                      day: "2-digit",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </p>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
       </ul>
+      <Spacing size={0.5} direction="vertical" />
+      <button
+        className="w-full rounded-sm bg-[#fafafc] p-2"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {isOpen ? "접기" : "더보기"}
+      </button>
     </section>
   );
 };

--- a/FE/apps/web/src/constants/API.ts
+++ b/FE/apps/web/src/constants/API.ts
@@ -84,6 +84,10 @@ const CALENDAR = {
     `calendars?year=${year}&month=${month}&date=${date}&duration=${duration}`,
 };
 
+const ANNOUNCEMENT = {
+  LIST: "/announcements",
+};
+
 Object.freeze(PROGRAM);
 Object.freeze(MEMBER);
 Object.freeze(USER);
@@ -92,7 +96,7 @@ Object.freeze(TEAM_BUILDING);
 Object.freeze(TEAM);
 Object.freeze(QUESTION);
 Object.freeze(CALENDAR);
-
+Object.freeze(ANNOUNCEMENT);
 export default {
   PROGRAM,
   MEMBER,
@@ -102,4 +106,5 @@ export default {
   TEAM,
   QUESTION,
   CALENDAR,
+  ANNOUNCEMENT,
 };

--- a/FE/apps/web/src/hooks/query/useAnnouncementsQuery.ts
+++ b/FE/apps/web/src/hooks/query/useAnnouncementsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCalendarEventsOnWeek } from "@/apis/calendar";
+import { getAnnouncements } from "@/apis/announcement";
+
+export const useAnnouncementsQuery = () => {
+  return useQuery({
+    queryKey: ["announcements"],
+    queryFn: () => getAnnouncements(),
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 10,
+  });
+};

--- a/FE/eeos_v2.json
+++ b/FE/eeos_v2.json
@@ -2098,6 +2098,35 @@
         }
       ],
       "responseMode": null
+    },
+    {
+      "uuid": "ac2a2c3d-6063-41a5-b366-4494da1289e5",
+      "type": "http",
+      "documentation": "공지사항 불러오기",
+      "method": "get",
+      "endpoint": "announcements",
+      "responses": [
+        {
+          "uuid": "2bd58c05-8b98-41be-b621-04def09fb3a6",
+          "body": "{\n  \"data\": {\n    \"announcements\": [\n      {\n        \"id\": 1,\n        \"title\": \"31기 신입모집 면접 도우미 모집\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }, {\n        \"id\": 2,\n        \"title\": \"31기 신입모집 면접 도우미 모집\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }, {\n        \"id\": 3,\n        \"title\": \"매우매우 중요한 공지!!!\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }\n    ]\n  },\n  \"message\": \"string\",\n  \"code\": \"string\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
     }
   ],
   "rootChildren": [
@@ -2184,6 +2213,10 @@
     {
       "type": "route",
       "uuid": "b90f0902-05b2-4213-b1e5-08d019ac8847"
+    },
+    {
+      "type": "route",
+      "uuid": "ac2a2c3d-6063-41a5-b366-4494da1289e5"
     }
   ],
   "proxyMode": false,


### PR DESCRIPTION
- #248

웹뷰 메인 화면에 에코노베이션 공지사항을 조회하고 펼쳐볼 수 있는 기능을 구현하였습니다.

## 주요 변경사항

### 공지사항 조회 API 및 DTO 추가

`/announcements` 엔드포인트를 호출하여 공지사항 목록을 가져오는 API 함수를 신규 작성하였습니다.
응답 데이터를 안전하게 다루기 위하여 `AnnouncementDto` 클래스를 정의하였고, `id`, `title`, `body`, `announcedAt`, `deadline`, `createdDate` 필드를 보유하도록 하였습니다.
또한 `constants/API.ts`에 `ANNOUNCEMENT.LIST` 경로 상수를 추가하여 다른 API 상수들과 동일한 컨벤션을 유지하도록 하였습니다.

### useAnnouncementsQuery 훅 추가

React Query 기반의 `useAnnouncementsQuery` 훅을 신규 작성하여 공지사항 데이터를 컴포넌트에서 사용할 수 있도록 하였습니다.
공지사항은 자주 변경되지 않는 데이터이므로 `staleTime` 5분, `cacheTime` 10분으로 설정하여 불필요한 네트워크 요청을 줄이도록 하였습니다.

### AnnouncementSection 컴포넌트 구현

기존에 placeholder 문구만 노출하던 `AnnouncementSection` 컴포넌트를 실제 공지사항 데이터를 렌더링하도록 수정하였습니다.
로딩 상태와 에러 상태를 각각 분기 처리하여 사용자에게 적절한 피드백을 제공하도록 하였습니다.
기본 상태에서는 공지일자(MM/DD)와 제목만 노출하고, "더보기" 버튼을 누르면 본문과 공지 일시까지 함께 펼쳐서 보여지는 토글 UI로 구현하였습니다.

### Mock 데이터 추가

`eeos_v2.json` 모킹 파일에 공지사항 GET 엔드포인트와 응답 데이터를 추가하여 백엔드 연동 전에도 프론트엔드 기능 검증이 가능하도록 하였습니다.