### PR TITLE
[FIX] 사용자의 분야가 올바르게 뜨지 않는 버그 수정

### DIFF
--- a/FE/apps/web/src/app/(webview)/mobile/setting/account/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/setting/account/page.tsx
@@ -1,11 +1,45 @@
-import ComingSoonScreen from "@/components/common/ComingSoonScreen";
+import AppSafeArea from "@/components/common/AppSafeArea/AppSafeArea";
+import Spacing from "@/components/common/Spacing";
+import AccountSettingHeader from "@/components/feature/webview-account-setting/AccountSettingHeader";
 import { SsgoiTransition } from "@ssgoi/react";
 
 const AppAccountSettingPage = () => {
   return (
     <SsgoiTransition id="/setting/account">
-      {/* <div>AppAccountSettingPage</div> */}
-      <ComingSoonScreen />
+      <AppSafeArea edges={["top"]}>
+        <AccountSettingHeader />
+        <div className="px-6">
+          <Spacing size={1.5} direction="vertical" />
+          <section>
+            <h3 className="text-lg font-medium">활동 상태</h3>
+            {/* 준비중 */}
+            <div className="mt-4 flex items-center gap-2 rounded-lg bg-[#F2F2F7] px-4 py-3">
+              <div className="h-3 w-3 rounded-full bg-green-500" />
+              <p className="text-sm font-medium text-[#767676]">AM</p>
+            </div>
+            <Spacing size={8} direction="vertical" unit="px" />
+            <p className="text-xs font-medium leading-[18.20px] text-[#767676]">
+              활동 상태 변경은 회장단에게 문의해주세요.
+            </p>
+          </section>
+
+          <Spacing size={4} direction="vertical" />
+          <section>
+            <div className="flex justify-between">
+              <div>
+                <h3 className="text-lg font-medium">파트</h3>
+              </div>
+              <select className="rounded-lg border border-[#D9D9D9] bg-white px-4 py-3 text-left text-sm font-medium text-[#767676]">
+                <option value="designer">디자이너(DE)</option>
+                <option value="planner">기획자(PM)</option>
+                <option value="developer">개발자(FE)</option>
+                <option value="developer">개발자(BE)</option>
+                <option value="developer">개발자(GAME)</option>
+              </select>
+            </div>
+          </section>
+        </div>
+      </AppSafeArea>
     </SsgoiTransition>
   );
 };

--- a/FE/apps/web/src/components/feature/webview-account-setting/AccountSettingHeader.tsx
+++ b/FE/apps/web/src/components/feature/webview-account-setting/AccountSettingHeader.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Spacing from "@/components/common/Spacing";
+import { ArrowLeft } from "@/components/icons/items/ArrotLeft";
+import { useRouter } from "next/navigation";
+
+const AccountSettingHeader = () => {
+  const router = useRouter();
+
+  return (
+    <header className="relative shadow-sm">
+      <button
+        className="absolute left-5"
+        onClick={() => {
+          router.back();
+        }}
+      >
+        <ArrowLeft />
+      </button>
+      <h1 className="text-basefont-medium text-center text-black">
+        계정 상태 변경
+      </h1>
+      <Spacing size={18} direction="vertical" unit="px" />
+    </header>
+  );
+};
+
+export default AccountSettingHeader;

--- a/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
@@ -23,7 +23,7 @@ const AnnouncementSection = () => {
       <h2 className="text-lg font-semibold">에코노베이션 공지사항</h2>
       <Spacing size={0.75} direction="vertical" />
       <ul className="flex flex-col gap-2">
-        {announcements.map(({ id, title, body, announcedAt }) => (
+        {announcements.slice(0, 3).map(({ id, title, body, announcedAt }) => (
           <li key={id} className="gap-4 rounded-lg bg-[#F2F2F7] p-3">
             <div className="flex items-center gap-1">
               {!isOpen && (

--- a/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import CharacterImage from "@/components/common/CharacterImage/Charactor-Image";
+import useRouteToWebviewScreenBridge from "@/hooks/bridge/useRouteToWebviewScreenBridge";
 import { useGetTwoMonthCalenderEventsQuery } from "@/hooks/query/useCalendarQuery";
+import { useCallback } from "react";
 
 const FIXED_HEIGHT = "min-h-[6rem]";
 
@@ -29,6 +31,12 @@ const HomeEventSection = () => {
     isLoading,
     isError,
   } = useGetTwoMonthCalenderEventsQuery();
+
+  const routeToWebviewScreen = useRouteToWebviewScreenBridge();
+
+  const handleViewAllPrograms = useCallback(() => {
+    routeToWebviewScreen({ uri: "/mobile/programs" });
+  }, [routeToWebviewScreen]);
 
   const baseClass = `rounded-t-xl bg-[#00c3d0] px-4 py-3.5 flex flex-col relative ${FIXED_HEIGHT} relative`;
 
@@ -63,9 +71,14 @@ const HomeEventSection = () => {
             아직 다가오는 일정이 없어요.
           </p>
         </div>
-        <p className="text-end text-[0.75rem] text-white">
+        <button
+          type="button"
+          aria-label="일정 전체보기"
+          onClick={handleViewAllPrograms}
+          className="text-end text-[0.75rem] text-white"
+        >
           일정 전체보기 {">"}
-        </p>
+        </button>
       </div>
     );
   }
@@ -126,6 +139,8 @@ const HomeEventSection = () => {
 
       <button
         type="button"
+        aria-label="일정 전체보기"
+        onClick={handleViewAllPrograms}
         className="absolute bottom-2 right-5 text-[0.75rem] text-white"
       >
         전체보기 {">"}

--- a/FE/apps/web/src/components/feature/webview-main/UserMetaSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/UserMetaSection.tsx
@@ -14,9 +14,9 @@ const UserMetaSection = () => {
       <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         {name.split(" ")[0]}
       </div>
-      <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
+      {/* <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         디자이너
-      </div>
+      </div> */}
       <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         {activeStatus.toUpperCase()}
       </div>

--- a/FE/apps/web/src/components/feature/webview-mypage/MobileUserInfoSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-mypage/MobileUserInfoSection.tsx
@@ -23,9 +23,9 @@ const MobileUserInfoSection = () => {
         <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           {name.split(" ")[0]}
         </div>
-        <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
+        {/* <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           디자이너
-        </div>
+        </div> */}
         <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           {activeStatus.toUpperCase()}
         </div>


### PR DESCRIPTION
- #250

웹뷰 메인/마이페이지 사용자 메타 영역에서 디자이너 필드를 제거하고, 계정 상태 변경 화면 초기 UI 및 일정 전체보기 진입점, 공지사항 노출 개수 제한 등 부수 개선을 진행하였습니다.

## 주요 변경사항

### 사용자 메타 영역에서 디자이너 필드 제거

웹뷰 메인 화면(`UserMetaSection`)과 마이페이지 화면(`MobileUserInfoSection`)의 사용자 메타 영역에서 하드코딩되어 있던 "디자이너" 칩을 제거하였습니다.
현재는 사용자별 파트 정보가 동적으로 연결되어 있지 않아 모든 사용자에게 동일하게 "디자이너"가 노출되던 문제가 있었습니다.
이에 따라 추후 파트 정보 연동 작업 전까지는 해당 영역을 노출하지 않도록 주석 처리하였습니다.

### 계정 상태 변경 화면 초기 UI 구현

`apps/web/src/app/(webview)/mobile/setting/account/page.tsx` 경로에 계정 상태 변경 화면의 초기 UI를 구현하였습니다.
기존 `ComingSoonScreen`으로 대체되어 있던 화면을 실제 UI로 교체하였으며, 활동 상태 영역과 파트 선택 영역을 포함하도록 하였습니다.
또한 헤더 컴포넌트(`AccountSettingHeader`)를 신규로 생성하여 뒤로가기 동작과 화면 타이틀을 담당하도록 분리하였습니다.
다만 활동 상태 영역과 파트 선택 영역의 데이터 연동은 이후 작업으로 분리되어 있으며, 현재는 정적인 마크업과 placeholder 옵션만 노출됩니다.

### 웹뷰 메인 일정 전체보기 버튼 동작 추가

웹뷰 메인 화면(`HomeEventSection`)의 "일정 전체보기" 진입점에 실제 동작을 연결하였습니다.
기존에는 진입점 UI만 존재하고 어떤 핸들러도 연결되어 있지 않아 터치해도 동작하지 않는 상태였습니다.
이번 작업에서는 이미 구현되어 있는 `useRouteToWebviewScreenBridge` 훅을 호출하여 Native 측에 `route-to-webview-screen` 메시지를 전송하도록 하였고, 이를 통해 탭바가 없는 풀스크린 WebView 스택 스크린에서 프로그램 페이지(`/mobile/programs`)가 로드되도록 하였습니다.
일정이 없는 빈 상태 분기와 일정이 있는 상태 분기 두 곳 모두에 동일한 핸들러를 연결하였으며, 빈 상태에서 사용되던 `<p>` 태그는 접근성과 터치 영역 확보를 위하여 `<button>` 요소로 변경하였습니다.

### 웹뷰 메인 공지사항 최대 3개 노출 제한

웹뷰 메인 화면(`AnnouncementSection`)의 공지사항 목록을 최대 3개까지만 노출하도록 변경하였습니다.
기존에는 백엔드에서 내려주는 모든 공지사항을 그대로 렌더링하였으나, 메인 화면에서는 최신 공지 일부만 노출하는 것이 적절하다고 판단되어 `slice(0, 3)`을 적용하였습니다.
