### PR TITLE
[RELEASE] v4.0.3 공지사항 탭 구현 및 버그 수정

### DIFF
--- a/FE/apps/native/app.config.ts
+++ b/FE/apps/native/app.config.ts
@@ -11,6 +11,7 @@ const config = {
     ios: {
       supportsTablet: true,
       bundleIdentifier: "com.blackcompany.eeos",
+      appleTeamId: "3XD9F9256D",
       googleServicesFile: "./GoogleService-Info.plist",
       entitlements: {
         "aps-environment": "production",

--- a/FE/apps/native/app.config.ts
+++ b/FE/apps/native/app.config.ts
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   expo: {
     name: "eeos",
     slug: "eeos",
@@ -10,7 +10,7 @@ module.exports = {
     newArchEnabled: true,
     ios: {
       supportsTablet: true,
-      bundleIdentifier: "com.geongyu09.xnative",
+      bundleIdentifier: "com.blackcompany.eeos",
       googleServicesFile: "./GoogleService-Info.plist",
       entitlements: {
         "aps-environment": "production",
@@ -33,7 +33,7 @@ module.exports = {
       googleServicesFile: "./google-services.json",
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
-      package: "com.geongyu09.xnative",
+      package: "com.blackcompany.eeos",
       // 웹뷰에서 http 도메인 허용. 빌드시에는 https로 변경 혹은 특정 도메인만 허용하도록 수정 필요
       usesCleartextTraffic: true,
       useNextNotificationsApi: true, // FCM을 위한 설정
@@ -80,8 +80,10 @@ module.exports = {
     },
     extra: {
       eas: {
-        projectId: "05949d1e-7d4a-4649-b8d7-84e37126e5a7",
+        projectId: "1cccc629-7c0b-4613-8646-e507982e2908",
       },
     },
   },
 };
+
+export default config;

--- a/FE/apps/web/src/apis/announcement.ts
+++ b/FE/apps/web/src/apis/announcement.ts
@@ -1,0 +1,16 @@
+import API from "@/constants/API";
+import { AnnouncementDto } from "./dtos/announcement";
+import { https } from "./instance";
+
+/**
+ * 모바일 홈 화면에서 사용하는 공지사항 가져오기 요청
+ */
+export const getAnnouncements = async (): Promise<AnnouncementDto[]> => {
+  const { data } = await https({
+    url: API.ANNOUNCEMENT.LIST,
+    method: "GET",
+  });
+  return (data?.data.announcements || []).map(
+    (item: any) => new AnnouncementDto(item),
+  );
+};

--- a/FE/apps/web/src/apis/dtos/announcement.ts
+++ b/FE/apps/web/src/apis/dtos/announcement.ts
@@ -1,0 +1,24 @@
+export class AnnouncementDto {
+  public readonly id: number;
+  public readonly title: string;
+  public readonly body: string;
+  public readonly announcedAt: number;
+  public readonly deadline: number;
+  public readonly createdDate: number;
+
+  constructor(data: {
+    id: number;
+    title: string;
+    body: string;
+    announcedAt: number;
+    deadline: number;
+    createdDate: number;
+  }) {
+    this.id = data?.id;
+    this.title = data?.title;
+    this.body = data?.body;
+    this.announcedAt = data?.announcedAt;
+    this.deadline = data?.deadline;
+    this.createdDate = data?.createdDate;
+  }
+}

--- a/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
@@ -8,7 +8,10 @@ import { SsgoiTransition } from "@ssgoi/react";
 
 const WebviewMainPage = () => {
   return (
-    <SsgoiTransition id="/main" className="min-h-screen bg-white">
+    <SsgoiTransition
+      id="/main"
+      className="relative max-h-screen min-h-screen overflow-auto bg-white"
+    >
       <div className="flex min-h-screen flex-col">
         <div>
           <section className="relative z-10 bg-[#F2F2F7] px-6 pt-16 shadow-[0px_-10px_10px_0px_rgba(34,43,69,0.21)]">

--- a/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
@@ -9,7 +9,7 @@ import { SsgoiTransition } from "@ssgoi/react";
 const WebviewMainPage = () => {
   return (
     <SsgoiTransition id="/main" className="min-h-screen bg-white">
-      <div className="flex h-screen flex-col">
+      <div className="flex min-h-screen flex-col">
         <div>
           <section className="relative z-10 bg-[#F2F2F7] px-6 pt-16 shadow-[0px_-10px_10px_0px_rgba(34,43,69,0.21)]">
             <div className="flex items-center justify-between">

--- a/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/main/page.tsx
@@ -5,7 +5,6 @@ import AnnouncementSection from "@/components/feature/webview-main/AnnouncementS
 import HelloSection from "@/components/feature/webview-main/HelloSection";
 import HomeEventSection from "@/components/feature/webview-main/HomeEventSection";
 import { SsgoiTransition } from "@ssgoi/react";
-// import UserMetaSection from "@/components/feature/webview-main/UserMetaSection";
 
 const WebviewMainPage = () => {
   return (
@@ -28,6 +27,9 @@ const WebviewMainPage = () => {
         <div className="grow px-6 shadow-[0px_-100px_10px_0px_rgba(34,43,69,0.21)]">
           <Spacing size={32} direction="vertical" unit="px" />
           <AnnouncementSection />
+        </div>
+        <div>
+          <Spacing size={32} direction="vertical" unit="px" />
         </div>
       </div>
     </SsgoiTransition>

--- a/FE/apps/web/src/app/(webview)/mobile/programs/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/programs/page.tsx
@@ -1,6 +1,6 @@
 import AppSafeArea from "@/components/common/AppSafeArea/AppSafeArea";
+import WebviewProgramsHeader from "@/components/feature/webview-programs/WebviewProgramsHeader";
 import WebviewProgramsSection from "@/components/feature/webview-programs/WebviewProgramsSection";
-import Calendar from "@/components/icons/items/CalendarIcon";
 import { SsgoiTransition } from "@ssgoi/react";
 
 const WebviewProgramPage = () => {
@@ -10,11 +10,7 @@ const WebviewProgramPage = () => {
         edges={["top", "left", "right", "bottom"]}
         classname="flex h-screen flex-col !overflow-visible"
       >
-        <header className="flex w-full shrink-0 justify-end">
-          <button className="rounded-full bg-[#F5F5F5] p-2">
-            <Calendar />
-          </button>
-        </header>
+        <WebviewProgramsHeader />
 
         <div className="h-4 shrink-0" />
         <WebviewProgramsSection />

--- a/FE/apps/web/src/app/(webview)/mobile/setting/account/page.tsx
+++ b/FE/apps/web/src/app/(webview)/mobile/setting/account/page.tsx
@@ -1,11 +1,45 @@
-import ComingSoonScreen from "@/components/common/ComingSoonScreen";
+import AppSafeArea from "@/components/common/AppSafeArea/AppSafeArea";
+import Spacing from "@/components/common/Spacing";
+import AccountSettingHeader from "@/components/feature/webview-account-setting/AccountSettingHeader";
 import { SsgoiTransition } from "@ssgoi/react";
 
 const AppAccountSettingPage = () => {
   return (
     <SsgoiTransition id="/setting/account">
-      {/* <div>AppAccountSettingPage</div> */}
-      <ComingSoonScreen />
+      <AppSafeArea edges={["top"]}>
+        <AccountSettingHeader />
+        <div className="px-6">
+          <Spacing size={1.5} direction="vertical" />
+          <section>
+            <h3 className="text-lg font-medium">활동 상태</h3>
+            {/* 준비중 */}
+            <div className="mt-4 flex items-center gap-2 rounded-lg bg-[#F2F2F7] px-4 py-3">
+              <div className="h-3 w-3 rounded-full bg-green-500" />
+              <p className="text-sm font-medium text-[#767676]">AM</p>
+            </div>
+            <Spacing size={8} direction="vertical" unit="px" />
+            <p className="text-xs font-medium leading-[18.20px] text-[#767676]">
+              활동 상태 변경은 회장단에게 문의해주세요.
+            </p>
+          </section>
+
+          <Spacing size={4} direction="vertical" />
+          <section>
+            <div className="flex justify-between">
+              <div>
+                <h3 className="text-lg font-medium">파트</h3>
+              </div>
+              <select className="rounded-lg border border-[#D9D9D9] bg-white px-4 py-3 text-left text-sm font-medium text-[#767676]">
+                <option value="designer">디자이너(DE)</option>
+                <option value="planner">기획자(PM)</option>
+                <option value="developer">개발자(FE)</option>
+                <option value="developer">개발자(BE)</option>
+                <option value="developer">개발자(GAME)</option>
+              </select>
+            </div>
+          </section>
+        </div>
+      </AppSafeArea>
     </SsgoiTransition>
   );
 };

--- a/FE/apps/web/src/components/feature/webview-account-setting/AccountSettingHeader.tsx
+++ b/FE/apps/web/src/components/feature/webview-account-setting/AccountSettingHeader.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Spacing from "@/components/common/Spacing";
+import { ArrowLeft } from "@/components/icons/items/ArrotLeft";
+import { useRouter } from "next/navigation";
+
+const AccountSettingHeader = () => {
+  const router = useRouter();
+
+  return (
+    <header className="relative shadow-sm">
+      <button
+        className="absolute left-5"
+        onClick={() => {
+          router.back();
+        }}
+      >
+        <ArrowLeft />
+      </button>
+      <h1 className="text-basefont-medium text-center text-black">
+        계정 상태 변경
+      </h1>
+      <Spacing size={18} direction="vertical" unit="px" />
+    </header>
+  );
+};
+
+export default AccountSettingHeader;

--- a/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
@@ -23,7 +23,7 @@ const AnnouncementSection = () => {
       <h2 className="text-lg font-semibold">에코노베이션 공지사항</h2>
       <Spacing size={0.75} direction="vertical" />
       <ul className="flex flex-col gap-2">
-        {announcements.map(({ id, title, body, announcedAt }) => (
+        {announcements.slice(0, 3).map(({ id, title, body, announcedAt }) => (
           <li key={id} className="gap-4 rounded-lg bg-[#F2F2F7] p-3">
             <div className="flex items-center gap-1">
               {!isOpen && (

--- a/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/AnnouncementSection.tsx
@@ -1,17 +1,70 @@
+"use client";
+
+import Spacing from "@/components/common/Spacing";
+import { useAnnouncementsQuery } from "@/hooks/query/useAnnouncementsQuery";
+import { useState } from "react";
+
 const AnnouncementSection = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data: announcements, isLoading, error } = useAnnouncementsQuery();
+
+  if (isLoading || !announcements) {
+    return <p>공지사항을 불러오는 중입니다...</p>;
+  }
+
+  if (error) {
+    return <p>공지사항을 불러오는 중 오류가 발생했습니다.</p>;
+  }
+
   return (
     <section>
       <p className="text-xs font-medium text-[#767676]">일정 리마인드</p>
       <h2 className="text-lg font-semibold">에코노베이션 공지사항</h2>
+      <Spacing size={0.75} direction="vertical" />
       <ul className="flex flex-col gap-2">
-        {/* <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 1</li>
-        <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 2</li>
-        <li className="rounded-lg bg-[#F2F2F7] p-2">공지사항 3</li> */}
-        <div className="rounded-xl bg-[#F2F2F7] p-4 text-sm">
-          <p>조만간 기능이 업데이트 될 예정입니다.</p>
-          <p>조금만 기다려주세요! 😊</p>
-        </div>
+        {announcements.map(({ id, title, body, announcedAt }) => (
+          <li key={id} className="gap-4 rounded-lg bg-[#F2F2F7] p-3">
+            <div className="flex items-center gap-1">
+              {!isOpen && (
+                <p className="shrink-0 text-sm font-medium">
+                  {new Date(announcedAt).toLocaleDateString("ko-KR", {
+                    month: "2-digit",
+                    day: "2-digit",
+                  })}
+                </p>
+              )}
+              <h3 className="font-medium">{title}</h3>
+            </div>
+
+            {isOpen && (
+              <>
+                <Spacing size={20} unit="px" direction="vertical" />
+                <p className="text-sm text-[#767676]">{body}</p>
+                <div>
+                  <Spacing size={20} unit="px" direction="vertical" />
+                  <p className="text-right text-xs text-[#767676]">
+                    {new Date(announcedAt).toLocaleDateString("ko-KR", {
+                      year: "numeric",
+                      month: "2-digit",
+                      day: "2-digit",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </p>
+                </div>
+              </>
+            )}
+          </li>
+        ))}
       </ul>
+      <Spacing size={0.5} direction="vertical" />
+      <button
+        className="w-full rounded-sm bg-[#fafafc] p-2"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {isOpen ? "접기" : "더보기"}
+      </button>
     </section>
   );
 };

--- a/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import CharacterImage from "@/components/common/CharacterImage/Charactor-Image";
+import useRouteToWebviewScreenBridge from "@/hooks/bridge/useRouteToWebviewScreenBridge";
 import { useGetTwoMonthCalenderEventsQuery } from "@/hooks/query/useCalendarQuery";
+import { useCallback } from "react";
 
 const FIXED_HEIGHT = "min-h-[6rem]";
 
@@ -29,6 +31,12 @@ const HomeEventSection = () => {
     isLoading,
     isError,
   } = useGetTwoMonthCalenderEventsQuery();
+
+  const routeToWebviewScreen = useRouteToWebviewScreenBridge();
+
+  const handleViewAllPrograms = useCallback(() => {
+    routeToWebviewScreen({ uri: "/mobile/programs" });
+  }, [routeToWebviewScreen]);
 
   const baseClass = `rounded-t-xl bg-[#00c3d0] px-4 py-3.5 flex flex-col relative ${FIXED_HEIGHT} relative`;
 
@@ -63,9 +71,14 @@ const HomeEventSection = () => {
             아직 다가오는 일정이 없어요.
           </p>
         </div>
-        <p className="text-end text-[0.75rem] text-white">
+        <button
+          type="button"
+          aria-label="일정 전체보기"
+          onClick={handleViewAllPrograms}
+          className="text-end text-[0.75rem] text-white"
+        >
           일정 전체보기 {">"}
-        </p>
+        </button>
       </div>
     );
   }
@@ -126,6 +139,8 @@ const HomeEventSection = () => {
 
       <button
         type="button"
+        aria-label="일정 전체보기"
+        onClick={handleViewAllPrograms}
         className="absolute bottom-2 right-5 text-[0.75rem] text-white"
       >
         전체보기 {">"}

--- a/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/HomeEventSection.tsx
@@ -35,7 +35,7 @@ const HomeEventSection = () => {
   const routeToWebviewScreen = useRouteToWebviewScreenBridge();
 
   const handleViewAllPrograms = useCallback(() => {
-    routeToWebviewScreen({ uri: "/mobile/programs" });
+    routeToWebviewScreen({ uri: `${window.location.origin}/mobile/programs` });
   }, [routeToWebviewScreen]);
 
   const baseClass = `rounded-t-xl bg-[#00c3d0] px-4 py-3.5 flex flex-col relative ${FIXED_HEIGHT} relative`;

--- a/FE/apps/web/src/components/feature/webview-main/UserMetaSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-main/UserMetaSection.tsx
@@ -14,9 +14,9 @@ const UserMetaSection = () => {
       <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         {name.split(" ")[0]}
       </div>
-      <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
+      {/* <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         디자이너
-      </div>
+      </div> */}
       <div className="rounded-full bg-white px-2  py-1 text-sm  font-medium">
         {activeStatus.toUpperCase()}
       </div>

--- a/FE/apps/web/src/components/feature/webview-mypage/MobileUserInfoSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-mypage/MobileUserInfoSection.tsx
@@ -23,9 +23,9 @@ const MobileUserInfoSection = () => {
         <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           {name.split(" ")[0]}
         </div>
-        <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
+        {/* <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           디자이너
-        </div>
+        </div> */}
         <div className="rounded-full bg-white px-2 py-1 text-sm font-medium text-black">
           {activeStatus.toUpperCase()}
         </div>

--- a/FE/apps/web/src/components/feature/webview-mypage/SettingButton.tsx
+++ b/FE/apps/web/src/components/feature/webview-mypage/SettingButton.tsx
@@ -1,12 +1,23 @@
+"use client";
+
 import Setting from "@/components/icons/items/Setting";
 import ROUTES from "@/constants/ROUTES";
-import Link from "next/link";
+import useRouteToWebviewScreenBridge from "@/hooks/bridge/useRouteToWebviewScreenBridge";
+import { useCallback } from "react";
 
 const SettingButton = () => {
+  const routeToWebviewScreen = useRouteToWebviewScreenBridge();
+
+  const handleOpenSetting = useCallback(() => {
+    routeToWebviewScreen({
+      uri: `${window.location.origin}${ROUTES.MOBILE.SETTING.MAIN}`,
+    });
+  }, [routeToWebviewScreen]);
+
   return (
-    <Link href={ROUTES.MOBILE.SETTING.MAIN}>
+    <button type="button" aria-label="설정 열기" onClick={handleOpenSetting}>
       <Setting />
-    </Link>
+    </button>
   );
 };
 

--- a/FE/apps/web/src/components/feature/webview-programs/WebviewProgramHeaderSection.tsx
+++ b/FE/apps/web/src/components/feature/webview-programs/WebviewProgramHeaderSection.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Spacing from "@/components/common/Spacing";
-import { ArrowRight } from "@/components/icons";
 import { ArrowLeft } from "@/components/icons/items/ArrotLeft";
-import PROGRAM from "@/constants/PROGRAM";
+import useGoBackBridge from "@/hooks/bridge/useGoBackBridge";
 import { useGetProgramByProgramId } from "@/hooks/query/useProgramQuery";
 import { useGetProgramId } from "@/hooks/usePrograms";
 import { SwitchCase } from "@toss/react";
@@ -24,6 +23,7 @@ function formatDeadlineText(deadLine: string) {
 const WebviewProgramHeaderSection = () => {
   const programId = useGetProgramId();
   const router = useRouter();
+  const goBackBridge = useGoBackBridge();
 
   const {
     data: programData,
@@ -36,12 +36,20 @@ const WebviewProgramHeaderSection = () => {
 
   const { deadLine, title, programStatus } = programData;
 
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+      return;
+    }
+    goBackBridge();
+  };
+
   return (
     <section className="sticky top-0 z-10 rounded-b-2xl border-b bg-white pt-[4.5rem]">
       <div className="relative">
         <button
           className="absolute left-5 top-1/2 -translate-y-1/2"
-          onClick={() => router.back()}
+          onClick={handleGoBack}
         >
           <ArrowLeft />
         </button>

--- a/FE/apps/web/src/components/feature/webview-programs/WebviewProgramsHeader.tsx
+++ b/FE/apps/web/src/components/feature/webview-programs/WebviewProgramsHeader.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Calendar from "@/components/icons/items/CalendarIcon";
+import useRouteToWebviewScreenBridge from "@/hooks/bridge/useRouteToWebviewScreenBridge";
+import { useCallback } from "react";
+
+const WebviewProgramsHeader = () => {
+  const routeToWebviewScreen = useRouteToWebviewScreenBridge();
+
+  const handleOpenCalendar = useCallback(() => {
+    routeToWebviewScreen({ uri: `${window.location.origin}/mobile/calendar` });
+  }, [routeToWebviewScreen]);
+
+  return (
+    <header className="flex w-full shrink-0 justify-end">
+      <button
+        type="button"
+        aria-label="캘린더 열기"
+        onClick={handleOpenCalendar}
+        className="rounded-full bg-[#F5F5F5] p-2"
+      >
+        <Calendar />
+      </button>
+    </header>
+  );
+};
+
+export default WebviewProgramsHeader;

--- a/FE/apps/web/src/constants/API.ts
+++ b/FE/apps/web/src/constants/API.ts
@@ -84,6 +84,10 @@ const CALENDAR = {
     `calendars?year=${year}&month=${month}&date=${date}&duration=${duration}`,
 };
 
+const ANNOUNCEMENT = {
+  LIST: "/announcements",
+};
+
 Object.freeze(PROGRAM);
 Object.freeze(MEMBER);
 Object.freeze(USER);
@@ -92,7 +96,7 @@ Object.freeze(TEAM_BUILDING);
 Object.freeze(TEAM);
 Object.freeze(QUESTION);
 Object.freeze(CALENDAR);
-
+Object.freeze(ANNOUNCEMENT);
 export default {
   PROGRAM,
   MEMBER,
@@ -102,4 +106,5 @@ export default {
   TEAM,
   QUESTION,
   CALENDAR,
+  ANNOUNCEMENT,
 };

--- a/FE/apps/web/src/hooks/query/useAnnouncementsQuery.ts
+++ b/FE/apps/web/src/hooks/query/useAnnouncementsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCalendarEventsOnWeek } from "@/apis/calendar";
+import { getAnnouncements } from "@/apis/announcement";
+
+export const useAnnouncementsQuery = () => {
+  return useQuery({
+    queryKey: ["announcements"],
+    queryFn: () => getAnnouncements(),
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 10,
+  });
+};

--- a/FE/eeos_v2.json
+++ b/FE/eeos_v2.json
@@ -2098,6 +2098,35 @@
         }
       ],
       "responseMode": null
+    },
+    {
+      "uuid": "ac2a2c3d-6063-41a5-b366-4494da1289e5",
+      "type": "http",
+      "documentation": "공지사항 불러오기",
+      "method": "get",
+      "endpoint": "announcements",
+      "responses": [
+        {
+          "uuid": "2bd58c05-8b98-41be-b621-04def09fb3a6",
+          "body": "{\n  \"data\": {\n    \"announcements\": [\n      {\n        \"id\": 1,\n        \"title\": \"31기 신입모집 면접 도우미 모집\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }, {\n        \"id\": 2,\n        \"title\": \"31기 신입모집 면접 도우미 모집\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }, {\n        \"id\": 3,\n        \"title\": \"매우매우 중요한 공지!!!\",\n        \"body\": \"안녕하세요! 면접 도우미를 모집합니다.\",\n        \"announcedAt\": 1774187000000,\n        \"deadline\": 1774396800000,\n        \"createdDate\": 1774187457249\n      }\n    ]\n  },\n  \"message\": \"string\",\n  \"code\": \"string\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
     }
   ],
   "rootChildren": [
@@ -2184,6 +2213,10 @@
     {
       "type": "route",
       "uuid": "b90f0902-05b2-4213-b1e5-08d019ac8847"
+    },
+    {
+      "type": "route",
+      "uuid": "ac2a2c3d-6063-41a5-b366-4494da1289e5"
     }
   ],
   "proxyMode": false,


### PR DESCRIPTION
## ✨ 신규 기능

1. 공지사항 탭 구현 (#249)
   - `/announcements` 엔드포인트 연동 API 함수와 `AnnouncementDto` 추가
   - `useAnnouncementsQuery` React Query 훅 신설 (staleTime 5분, cacheTime 10분)
   - `AnnouncementSection`에서 로딩/에러 상태 분기 + "더보기" 토글로 본문·공지일시 펼침 UI 구현
   - `eeos_v2.json` Mock 데이터 추가

2. 웹뷰 계정 상태 변경 화면 초기 UI 구현
   - `(webview)/mobile/setting/account` 페이지 구현
   - 활동 상태 영역 + 파트 선택 영역 정적 마크업 추가 (데이터 연동은 후속 작업)

3. **네이티브 브릿지 연동 확장**
   - 마이페이지 설정 버튼: `useRouteToWebviewScreenBridge`로 네이티브 새 웹뷰 스크린 오픈
   - 프로그램 화면 뒤로가기 버튼: `useGoBackBridge`로 히스토리 없을 시 네이티브 뒤로가기 호출
   - 프로그램 화면 캘린더 버튼: `WebviewProgramsHeader`로 분리 후 캘린더 화면 이동
   - 메인 일정 전체보기 버튼: `/mobile/programs`로 이동하도록 핸들러 연결 (빈 상태 `<p>` → `<button>` 변경)

## 🐛 버그 수정

5. **사용자 분야 표시 오류 수정** (#251)
   - 메인/마이페이지의 하드코딩된 "디자이너" 칩 제거 (모든 사용자에 동일 노출되던 문제) — 파트 정보 동적 연동 전까지 주석 처리

6. **웹뷰 메인 화면 스크롤 동작 수정**
   - 컨테이너 `h-screen` → `min-h-screen` 변경으로 콘텐츠 길이에 맞게 영역 확장

7. **웹뷰 메인 → 프로그램 라우팅 수정**
   - 일정 전체보기 라우팅 경로를 절대 URL로 변경하여 정상 이동

## 🔧 기타 (chore)

8. **iOS `appleTeamId` 설정 추가** (`app.config.ts`)
9. **변경된 번들 아이디 적용**
