### PR TITLE
[FEAT] 헤더에 개발자 페이지 이동 버튼 추가

### DIFF
--- a/FE/apps/web/src/components/common/header/DeveloperPageBtn.tsx
+++ b/FE/apps/web/src/components/common/header/DeveloperPageBtn.tsx
@@ -1,0 +1,18 @@
+const DEVELOPER_PAGE_URL = process.env.NEXT_PUBLIC_DEVELOPER_PAGE_URL;
+
+const DeveloperPageBtn = () => {
+  if (!DEVELOPER_PAGE_URL) return null;
+
+  return (
+    <a
+      href={DEVELOPER_PAGE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-lg bg-gradient-to-r from-tertiary-20 to-slack px-4 py-2 text-sm font-medium text-background transition-colors"
+    >
+      개발자 페이지
+    </a>
+  );
+};
+
+export default DeveloperPageBtn;

--- a/FE/apps/web/src/components/common/header/HeaderNavSection.tsx
+++ b/FE/apps/web/src/components/common/header/HeaderNavSection.tsx
@@ -2,6 +2,7 @@
 
 import CalendarBtn from "./CalendarBtn";
 import CreateBtn from "./CreateBtn";
+import DeveloperPageBtn from "./DeveloperPageBtn";
 import LoginRedirectBtn from "./LoginRedirectBtn";
 import ManageRedirectButton from "./ManageRedirectButton";
 import UserBtn from "./UserBtn";
@@ -29,6 +30,7 @@ const HeaderNavSection = ({ isAdmin }: HeaderNavSectionProps) => {
     <section className="flex w-fit items-center gap-4 sm:gap-8">
       {isLoggedIn ? (
         <>
+          <DeveloperPageBtn />
           <CalendarBtn />
           <UserBtn />
           <LogoutBtn />


### PR DESCRIPTION
- #254

헤더 네비게이션에 외부 개발자 페이지로 이동하는 버튼을 추가하였습니다. 로그인 상태의 사용자에게만 노출되며, 이동 대상 URL은 환경 변수로 주입받아 동작합니다.

## 주요 변경사항

### 개발자 페이지 이동 버튼 추가

헤더에서 외부 개발자(에코노베이션 인증) 페이지로 이동할 수 있는 `DeveloperPageBtn` 컴포넌트를 신규 추가하였습니다.

이동 대상 URL은 하드코딩하지 않고 `NEXT_PUBLIC_DEVELOPER_PAGE_URL` 환경 변수에서 주입받도록 구성하였습니다. 환경 변수가 설정되어 있지 않은 경우에는 버튼을 렌더링하지 않고 `null`을 반환하여, 환경별로 노출 여부가 안전하게 제어되도록 하였습니다.

버튼은 `target="_blank"`와 `rel="noopener noreferrer"`를 지정하여 새 탭에서 안전하게 열리도록 하였으며, 그라데이션 배경(`tertiary-20` → `slack`)을 적용해 기존 헤더 버튼들과 시각적으로 구분되도록 스타일링하였습니다.

### 헤더 네비게이션 연동

`HeaderNavSection`의 로그인 상태(`isLoggedIn`) 분기 내부에 `DeveloperPageBtn`을 배치하여, 로그인한 사용자에게만 캘린더·유저·로그아웃 버튼과 함께 개발자 페이지 버튼이 노출되도록 하였습니다.
