### PR TITLE
[FEAT] SSO 로그인 URL에 client-id 파라미터 적용

### DIFF
--- a/FE/apps/native/src/constants/webview.ts
+++ b/FE/apps/native/src/constants/webview.ts
@@ -18,7 +18,7 @@ export const SSO_PATH = {
   LOGIN:
     SSO_BASE_URL +
     "?client-type=APP" +
-    "&redirect-url=" +
-    WEBVIEW_PATH.OAUTH_REDIRECT,
+    "&client-id=" +
+    process.env.EXPO_PUBLIC_SSO_CLIENT_ID,
   SIGN_UP: SSO_BASE_URL + "/signup",
 } as const;


### PR DESCRIPTION
- #256

SSO 로그인 요청 시 전달하는 파라미터를 `client-id` 기반으로 변경하였습니다.

## 주요 변경사항

### SSO 로그인 URL 파라미터 변경

기존에는 SSO 로그인 요청 시 `redirect-url` 파라미터로 OAuth 리다이렉트 경로(`WEBVIEW_PATH.OAUTH_REDIRECT`)를 전달하였습니다.
이를 `client-id` 파라미터로 `EXPO_PUBLIC_SSO_CLIENT_ID` 환경변수 값을 전달하도록 변경하였습니다.

## 리뷰 주의사항

- `EXPO_PUBLIC_SSO_CLIENT_ID` 환경변수가 빌드 환경에 정의되어 있어야 정상 동작합니다.
