### PR TITLE
[RELEASE] v4.0.5 SSO client-id 파라미터 적용 및 개발자 페이지 버튼 추가

### DIFF
--- a/FE/apps/native/src/constants/webview.ts
+++ b/FE/apps/native/src/constants/webview.ts
@@ -18,7 +18,7 @@ export const SSO_PATH = {
   LOGIN:
     SSO_BASE_URL +
     "?client-type=APP" +
-    "&redirect-url=" +
-    WEBVIEW_PATH.OAUTH_REDIRECT,
+    "&client-id=" +
+    process.env.EXPO_PUBLIC_SSO_CLIENT_ID,
   SIGN_UP: SSO_BASE_URL + "/signup",
 } as const;

--- a/FE/apps/web/src/components/common/header/DeveloperPageBtn.tsx
+++ b/FE/apps/web/src/components/common/header/DeveloperPageBtn.tsx
@@ -1,0 +1,18 @@
+const DEVELOPER_PAGE_URL = process.env.NEXT_PUBLIC_DEVELOPER_PAGE_URL;
+
+const DeveloperPageBtn = () => {
+  if (!DEVELOPER_PAGE_URL) return null;
+
+  return (
+    <a
+      href={DEVELOPER_PAGE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-lg bg-gradient-to-r from-tertiary-20 to-slack px-4 py-2 text-sm font-medium text-background transition-colors"
+    >
+      개발자 페이지
+    </a>
+  );
+};
+
+export default DeveloperPageBtn;

--- a/FE/apps/web/src/components/common/header/HeaderNavSection.tsx
+++ b/FE/apps/web/src/components/common/header/HeaderNavSection.tsx
@@ -2,6 +2,7 @@
 
 import CalendarBtn from "./CalendarBtn";
 import CreateBtn from "./CreateBtn";
+import DeveloperPageBtn from "./DeveloperPageBtn";
 import LoginRedirectBtn from "./LoginRedirectBtn";
 import ManageRedirectButton from "./ManageRedirectButton";
 import UserBtn from "./UserBtn";
@@ -29,6 +30,7 @@ const HeaderNavSection = ({ isAdmin }: HeaderNavSectionProps) => {
     <section className="flex w-fit items-center gap-4 sm:gap-8">
       {isLoggedIn ? (
         <>
+          <DeveloperPageBtn />
           <CalendarBtn />
           <UserBtn />
           <LogoutBtn />


### PR DESCRIPTION
## 📦 릴리즈 개요

`develop` 브랜치에 머지된 SSO 로그인 파라미터 개선과 개발자 페이지 이동 버튼 기능을 `main`에 반영합니다.

## ✨ 신규 기능

1. **헤더에 개발자 페이지 이동 버튼 추가** (#255, #254)
   - 헤더 네비게이션에 외부 개발자(에코노베이션 인증) 페이지로 이동하는 `DeveloperPageBtn` 컴포넌트 신규 추가
   - 이동 대상 URL은 `NEXT_PUBLIC_DEVELOPER_PAGE_URL` 환경 변수에서 주입받으며, 미설정 시 `null` 반환으로 노출 여부를 안전하게 제어
   - `target="_blank"` + `rel="noopener noreferrer"`로 새 탭 안전 오픈, 그라데이션 배경(`tertiary-20` → `slack`)으로 기존 버튼과 시각적 구분
   - `HeaderNavSection`의 로그인 상태(`isLoggedIn`) 분기 내부에 배치하여 로그인한 사용자에게만 노출

## 🔧 변경 사항

2. **SSO 로그인 URL에 client-id 파라미터 적용** (#257, #256)
   - SSO 로그인 요청 파라미터를 기존 `redirect-url`(`WEBVIEW_PATH.OAUTH_REDIRECT`) 방식에서 `client-id` 기반으로 변경
   - `EXPO_PUBLIC_SSO_CLIENT_ID` 환경 변수 값을 전달하도록 수정

## ⚠️ 배포 주의사항

- `NEXT_PUBLIC_DEVELOPER_PAGE_URL` (Web) 환경 변수 설정 필요 — 미설정 시 개발자 페이지 버튼 미노출
- `EXPO_PUBLIC_SSO_CLIENT_ID` (Native) 환경 변수가 빌드 환경에 정의되어 있어야 SSO 로그인 정상 동작

## 📝 포함 커밋

- 322aa8a5 [FEAT] SSO 로그인 URL에 client-id 파라미터 적용 (#257)
- b1161e40 [FEAT] 헤더에 개발자 페이지 이동 버튼 추가 (#255)
